### PR TITLE
Protect side-effectful API routes from cross-origin requests

### DIFF
--- a/src/app/api/install-deps/route.ts
+++ b/src/app/api/install-deps/route.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { promisify } from 'util';
 import { findContractDeploymentsRoot } from '@/lib/deployments';
 import { assertWithinDir } from '@/lib/path-validation';
+import { rejectCrossOriginRequest } from '@/lib/request-origin';
 
 const execAsync = promisify(exec);
 
@@ -18,6 +19,9 @@ const pathExists = async (targetPath: string) => {
 };
 
 export async function POST(req: NextRequest) {
+  const crossOriginResponse = rejectCrossOriginRequest(req);
+  if (crossOriginResponse) return crossOriginResponse;
+
   try {
     const json = await req.json();
     const { network, upgradeId, forceInstall } = json;

--- a/src/app/api/sign/__tests__/route.test.ts
+++ b/src/app/api/sign/__tests__/route.test.ts
@@ -16,11 +16,14 @@ const { POST } = await import('../route');
 const VALID_DOMAIN_HASH = '0x' + 'a'.repeat(64);
 const VALID_MESSAGE_HASH = '0x' + 'b'.repeat(64);
 
-function createRequest(body: Record<string, unknown>): NextRequest {
+function createRequest(
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {}
+): NextRequest {
   return new NextRequest('http://localhost/api/sign', {
     method: 'POST',
     body: JSON.stringify(body),
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...headers },
   });
 }
 
@@ -38,6 +41,55 @@ describe('POST /api/sign', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
+  });
+
+  describe('request origin checks', () => {
+    it('rejects requests with a mismatched Origin header', async () => {
+      const res = await POST(
+        createRequest(
+          {
+            domainHash: VALID_DOMAIN_HASH,
+            messageHash: VALID_MESSAGE_HASH,
+          },
+          { Origin: 'https://example.com' }
+        )
+      );
+
+      expect(res.status).toBe(403);
+      expect(mockCheckLedgerAvailability).not.toHaveBeenCalled();
+      expect(mockSignDomainAndMessageHash).not.toHaveBeenCalled();
+    });
+
+    it('rejects browser requests marked as cross-site', async () => {
+      const res = await POST(
+        createRequest(
+          {
+            domainHash: VALID_DOMAIN_HASH,
+            messageHash: VALID_MESSAGE_HASH,
+          },
+          { 'Sec-Fetch-Site': 'cross-site' }
+        )
+      );
+
+      expect(res.status).toBe(403);
+      expect(mockCheckLedgerAvailability).not.toHaveBeenCalled();
+      expect(mockSignDomainAndMessageHash).not.toHaveBeenCalled();
+    });
+
+    it('allows same-origin browser requests', async () => {
+      const res = await POST(
+        createRequest(
+          {
+            domainHash: VALID_DOMAIN_HASH,
+            messageHash: VALID_MESSAGE_HASH,
+          },
+          { Origin: 'http://localhost', 'Sec-Fetch-Site': 'same-origin' }
+        )
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockSignDomainAndMessageHash).toHaveBeenCalled();
+    });
   });
 
   describe('missing required fields', () => {

--- a/src/app/api/sign/route.ts
+++ b/src/app/api/sign/route.ts
@@ -4,9 +4,13 @@ import {
   signDomainAndMessageHash,
 } from '@/lib/ledger-signing';
 import { HashSchema } from '@/lib/config-schemas';
+import { rejectCrossOriginRequest } from '@/lib/request-origin';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function POST(req: NextRequest) {
+  const crossOriginResponse = rejectCrossOriginRequest(req);
+  if (crossOriginResponse) return crossOriginResponse;
+
   try {
     const {
       domainHash,

--- a/src/app/api/validate/__tests__/route.test.ts
+++ b/src/app/api/validate/__tests__/route.test.ts
@@ -11,11 +11,14 @@ jest.unstable_mockModule('@/lib/validation-service', () => ({
 
 const { POST } = await import('../route');
 
-function createRequest(body: Record<string, unknown>): NextRequest {
+function createRequest(
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {}
+): NextRequest {
   return new NextRequest('http://localhost/api/validate', {
     method: 'POST',
     body: JSON.stringify(body),
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...headers },
   });
 }
 
@@ -28,6 +31,38 @@ describe('POST /api/validate', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
+  });
+
+  it('rejects requests with a mismatched Origin header', async () => {
+    const res = await POST(
+      createRequest(
+        {
+          upgradeId: '2025-08-01-upgrade-qux',
+          network: 'zeronet',
+          userType: 'base-sc',
+        },
+        { Origin: 'https://example.com' }
+      )
+    );
+
+    expect(res.status).toBe(403);
+    expect(mockValidateUpgrade).not.toHaveBeenCalled();
+  });
+
+  it('rejects browser requests marked as cross-site', async () => {
+    const res = await POST(
+      createRequest(
+        {
+          upgradeId: '2025-08-01-upgrade-qux',
+          network: 'zeronet',
+          userType: 'base-sc',
+        },
+        { 'Sec-Fetch-Site': 'cross-site' }
+      )
+    );
+
+    expect(res.status).toBe(403);
+    expect(mockValidateUpgrade).not.toHaveBeenCalled();
   });
 
   it('accepts zeronet as a supported network', async () => {

--- a/src/app/api/validate/route.ts
+++ b/src/app/api/validate/route.ts
@@ -1,8 +1,12 @@
 import { validateUpgrade } from '@/lib/validation-service';
 import { NextRequest, NextResponse } from 'next/server';
 import { NetworkType } from '@/lib/types';
+import { rejectCrossOriginRequest } from '@/lib/request-origin';
 
 export async function POST(req: NextRequest) {
+  const crossOriginResponse = rejectCrossOriginRequest(req);
+  if (crossOriginResponse) return crossOriginResponse;
+
   try {
     const json = await req.json();
     const { upgradeId, network, userType } = json;

--- a/src/lib/request-origin.ts
+++ b/src/lib/request-origin.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const SAFE_FETCH_SITE_VALUES = new Set(['same-origin', 'none']);
+
+export function rejectCrossOriginRequest(req: NextRequest): NextResponse | null {
+  const origin = req.headers.get('origin');
+  if (origin && origin !== req.nextUrl.origin) {
+    return NextResponse.json({ error: 'Cross-origin requests are not allowed' }, { status: 403 });
+  }
+
+  const secFetchSite = req.headers.get('sec-fetch-site');
+  if (secFetchSite && !SAFE_FETCH_SITE_VALUES.has(secFetchSite.toLowerCase())) {
+    return NextResponse.json({ error: 'Cross-origin requests are not allowed' }, { status: 403 });
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add a shared request-origin guard for side-effectful local API routes
- reject mismatched Origin headers and cross-site Sec-Fetch-Site browser requests before parsing request bodies
- cover /api/sign and /api/validate origin checks in route tests

## Security context
The tool is intended to run on localhost and exposes POST routes that can trigger Ledger signing, dependency installation, or validation work. These routes should only be reachable from the tool's own UI or non-browser clients, not from arbitrary cross-origin browser contexts.

## Testing
- git diff --check
