### PR TITLE
fix(security): enforce HTTPS for rpcUrl in validation config schema

### DIFF
--- a/src/lib/config-schemas.ts
+++ b/src/lib/config-schemas.ts
@@ -75,7 +75,10 @@ export const TaskOriginValidationConfigSchema = z.object({
 export const TaskConfigSchema = z.object({
   cmd: z.string(),
   ledgerId: z.number().int().nonnegative(),
-  rpcUrl: z.string().url().min(1),
+  rpcUrl: z.string().url().min(1).refine(
+    (val) => val.startsWith('https://'),
+    (val) => ({ message: `rpcUrl must use HTTPS (got: ${val})` })
+  ),
   expectedDomainAndMessageHashes: ExpectedHashesSchema,
   stateOverrides: z.array(StateOverrideSchema),
   stateChanges: z.array(StateChangeSchema),


### PR DESCRIPTION
## Summary

The README documents `rpcUrl` as an HTTPS endpoint, but the schema accepts any URL scheme. For a tool that signs governance transactions, this is a real attack surface — added `.refine()` to enforce `https://`.

## The drift

**README.md:169** — rpcUrl is documented as:
> "**rpcUrl** — HTTPS RPC endpoint used for simulation"

**src/lib/config-schemas.ts:78** — actual schema:
```typescript
rpcUrl: z.string().url()
```

`z.string().url()` accepts `http://`, `ws://`, `wss://`, `file://` — anything that parses as a URL. The documentation says one thing, the enforced contract says another.

## Why this matters for a signing tool

The signing flow simulates a transaction over the configured RPC to display the resulting state diff to the signer. The signer reviews that diff and signs a hash derived from it.

An attacker positioned on the network path to an HTTP RPC (corporate proxy, untrusted Wi-Fi, compromised ISP, etc.) can:

1. Intercept the `eth_call` / state simulation response
2. Return a benign-looking state diff
3. Wait for the signer to approve a hash that matches the attacker-supplied state
4. The signed transaction, when broadcast, performs whatever the attacker chose

The simulation is the signer's only window into what they're approving. If that window is HTTP, the signer is trusting the network.

HTTPS doesn't eliminate this entirely (the RPC provider itself could be compromised), but it closes the MITM vector that's trivially exploitable on hostile networks.

## The fix

```diff
- rpcUrl: z.string().url()
+ rpcUrl: z.string().url().refine(
+   (val) => val.startsWith('https://'),
+   (val) => ({ message: `rpcUrl must use HTTPS (got: ${val})` })
+ )
```

- Existing `z.string().url()` is preserved — still rejects malformed URLs
- `.refine()` adds the HTTPS check on top
- Error message echoes the offending URL so operators get immediate, actionable feedback

## Verification

- ✅ One file modified: `src/lib/config-schemas.ts`
- ✅ 4 insertions, 1 deletion
- ✅ Existing URL validation preserved
- ✅ HTTP/WS/WSS URLs now fail at config load with a clear error
- ✅ HTTPS URLs continue to work without change