### PR TITLE
fix: exclude task-signing-tool folder from tarball, not signer-tool

### DIFF
--- a/src/lib/task-origin-validate.ts
+++ b/src/lib/task-origin-validate.ts
@@ -34,8 +34,7 @@ async function getAllFilesRecursively(
 
   const entries = await fs.readdir(currentDir, { withFileTypes: true });
   const files: string[] = [];
-  // Exclude cache, out, and signer-tool folders from the tarball
-  const excludedFolders = ['cache', 'out', 'signer-tool'];
+  const excludedFolders = ['cache', 'out', 'task-signing-tool']; // matches documented clone directory name in README.md
 
   for (const entry of entries) {
     const fullPath = path.join(currentDir, entry.name);


### PR DESCRIPTION
## Summary

The tarball exclusion list in `task-origin-validate.ts` referenced `signer-tool`, but the documented and actual repo directory name is `task-signing-tool`. When the tool ends up nested under a task folder, the wrong exclusion name silently changes tarball hashes.

## The bug

**src/lib/task-origin-validate.ts:38** — current exclusion list:
```typescript
const excludedFolders = ['cache', 'out', 'signer-tool'];
```

**README.md:39** — clone instructions:
```bash
git clone https://github.com/base/task-signing-tool.git
```

**The actual GitHub repo name** is `task-signing-tool` (this repo).

There is no `signer-tool` directory anywhere in the documented workflow.

## When it breaks

If the signing tool lives as a subdirectory inside a task folder — e.g.:
- Added as a git submodule for reproducible task validation
- Cloned alongside the task for convenience
- Installed via a nested setup script

…then its source files get included in the tarball that the validator hashes. The hash is computed deterministically from the task files; including the tool itself makes the hash depend on the tool version too.

The result: signers running the same task on different machines get different hashes, the validation step fails, and the error message just says "validation failed" with no hint that the tarball content drifted.

## The fix

```diff
- const excludedFolders = ['cache', 'out', 'signer-tool'];
+ const excludedFolders = ['cache', 'out', 'task-signing-tool']; // matches documented clone directory name in README.md
```

Single string change. Added an inline comment explaining the why, so future maintainers don't "fix" it back to `signer-tool`.

## Verification

- ✅ One file modified: `src/lib/task-origin-validate.ts`
- ✅ Inline comment references the README for context
- ✅ `cache` and `out` (the existing valid exclusions) untouched