### PR TITLE
feat: support active EVM signing flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,60 +32,53 @@ git clone https://github.com/base/task-signing-tool.git
 
 ### Expected Directory Layout
 
-Place this repository at the root of your task repository. Network folders (e.g., `mainnet`, `sepolia`, `zeronet`) must live alongside it, and each task must be a date-prefixed folder inside a network folder.
+Place this repository at the root of your task repository. Tasks are discovered from
+`active/evm/tasks/<task-id>/config/<network>/validations/` and appear in the normal signer UI flow.
 
-```12:40:root-of-your-task-repo
-contract-deployments/             # your task repo root (example)
-├─ task-signing-tool/             # this repo cloned here
-│  ├─ src/
-│  └─ ...
-├─ mainnet/                       # network directory
-│  ├─ 2025-06-04-upgrade-foo/     # task directory (YYYY-MM-DD-task-name)
-│  │  ├─ README.md                # optional, used for status parsing
-│  │  ├─ validations/
-│  │  │  ├─ base-sc.json          # config for "Base SC" user type
-│  │  │  ├─ coinbase.json         # config for "Coinbase" user type
-│  │  │  └─ op.json               # config for "OP" user type
-│  │  └─ foundry-project/         # directory where you run Foundry scripts
-│  │     └─ ...
-│  ├─ 2025-07-12-upgrade-bar/
-│  │  └─ ...
-│  └─ signatures/                 # signatures directory (separate from tasks)
-│     ├─ 2025-06-04-upgrade-foo/  # matches task directory name
-│     │  ├─ creator-signature.json
-│     │  ├─ base-facilitator-signature.json
-│     │  └─ base-sc-facilitator-signature.json
-│     └─ 2025-07-12-upgrade-bar/
-│        └─ ...
-├─ sepolia/
-│  ├─ 2025-05-10-upgrade-baz/
-│  │  └─ ...
-│  └─ signatures/
-│     └─ 2025-05-10-upgrade-baz/
-│        └─ ...
-└─ zeronet/
-   ├─ 2025-08-01-upgrade-qux/
-   │  └─ ...
-   └─ signatures/
-      └─ 2025-08-01-upgrade-qux/
-         └─ ...
+```text
+contract-deployments/
+├─ task-signing-tool/
+├─ active/
+│  └─ evm/
+│     ├─ tasks/
+│     │  ├─ 2026-06-18-beryl-1/
+│     │  │  ├─ README.md
+│     │  │  ├─ config/
+│     │  │  │  └─ mainnet/
+│     │  │  │     ├─ validations/
+│     │  │  │     ├─ signatures/
+│     │  │  │     ├─ network.env
+│     │  │  │     └─ .env
+│     │  └─ 2026-06-18-beryl-2/
+│     │     └─ config/
+│     ├─ script/
+│     │  └─ common/
+│     ├─ Makefile
+│     ├─ README.md
+│     └─ foundry.toml
+└─ archive/
 ```
 
-Key requirements and notes:
+Notes:
 
+- **Signer experience**: The UI lists active tasks first, then asks you to choose one of the task's ready-to-sign network configs.
 - **Networks**: Supported networks are listed in `src/lib/constants.ts` and currently include `mainnet`, `sepolia`, `sepolia-alpha`, and `zeronet`.
-- **Task folder naming**: Task directories must begin with a date prefix, `YYYY-MM-DD-`, for example `2025-06-04-upgrade-foo`. The UI lists only folders matching that pattern.
-- **Validation configs**: For each task, place config files under `validations/` named by user type in kebab-case plus `.json`:
-  - "Base SC" → `base-sc.json`
-  - "Coinbase" → `coinbase.json`
-  - "OP" → `op.json`
-- **Task origin signatures**: By default, tasks require three signature files stored in `<network>/signatures/<task-name>/`: `creator-signature.json`, `base-facilitator-signature.json`, and `base-sc-facilitator-signature.json`. Signatures are stored separately from task directories to avoid changing the tarball content. Use the `genTaskOriginSig.ts` script to generate these. Set `skipTaskOriginValidation: true` in the validation config to opt out.
-- **Script execution**: The tool executes Foundry from the task directory root (`<network>/<task>/`). Ensure your Foundry project or script context is available under that path; the tool will run the `cmd` specified in your validation config. Temporary outputs like `temp-script-output.txt` will be written there.
-- **Optional README parsing**: If `<network>/<task>/README.md` exists, the tool may parse it to display status and execution links.
+- **Validation configs**: Place config files under `active/evm/tasks/<task-id>/config/<network>/validations/` with concise human-readable names, such as `coinbase-signer.json` or `security-council-signer.json`.
+- **Script execution**: Validation commands run from `active/evm/`, so validation `cmd` values should reference scripts relative to that directory.
+- **Task origin verification**: Task-origin signatures are verified over `active/evm/`, which is the same directory used for simulation.
+- **Signature storage**: Store signatures in `active/evm/tasks/<task-id>/config/<network>/signatures/`. The signer tool excludes the nested `signatures/` directory from the signed tarball, so generating signatures does not change the attested payload.
+
+Generate task-origin signatures with:
+
+```bash
+tsx task-signing-tool/scripts/genTaskOriginSig.ts sign \
+  --task-folder active/evm \
+  --signature-path active/evm/tasks/2026-06-18-beryl-1/config/mainnet/signatures
+```
 
 ### Task README structure
 
-When present, each task's `README.md` is parsed to populate the UI. Place it at `<network>/<YYYY-MM-DD-slug>/README.md` and follow these rules:
+When present, `active/evm/tasks/<task-id>/config/<network>/README.md`, `active/evm/tasks/<task-id>/README.md`, or `active/evm/README.md` is parsed to populate the UI. Follow these rules:
 
 - **Status line (required for status display)**: Include a line containing `Status:` within the first 20 lines. Recognized values are `PENDING`, `READY TO SIGN`, and `EXECUTED` (case-insensitive). If `EXECUTED` is not present and `READY TO SIGN` is not present, the status is treated as `PENDING`. Supported formats:
   - **Single-line with link (any one of these)**:
@@ -100,7 +93,7 @@ When present, each task's `README.md` is parsed to populate the UI. Place it at 
 
 - **Title (optional)**: You may start with a `#` title. It is ignored for parsing the description fallback, but is fine for readability.
 
-- **Task name display**: The UI derives the display name from the folder slug after the date (e.g., `2025-06-04-upgrade-system-config` → `Upgrade System Config`). Choose meaningful slugs.
+- **Task name display**: The UI uses the first `#` heading when present, otherwise it falls back to the formatted task folder name.
 
 Examples
 
@@ -156,7 +149,7 @@ Executed upgrade; links include both onchain transaction and governance proposal
 
 ### Validation file structure
 
-Validation configs live under each task directory at `<network>/<YYYY-MM-DD-slug>/validations/` and are selected by user type:
+Validation configs live under `active/evm/tasks/<task-id>/config/<network>/validations/` and are selected by user type:
 
 - `base-sc.json` for **Base SC**
 - `coinbase.json` for **Coinbase**
@@ -196,7 +189,7 @@ Notes:
 
 - Sorting is not required; the tool sorts by address and storage slot for comparison.
 - The tool reads `rpcUrl` and `ledgerId` directly from this file.
-- When task origin validation is enabled, three signature files must exist in `<network>/signatures/<task-name>/` (see **Task Origin Signing** below).
+- When task origin validation is enabled, three signature files must exist in `active/evm/tasks/<task-id>/config/<network>/signatures/` (see **Task Origin Signing** below).
 
 Minimal example (`validations/base-sc.json`):
 
@@ -247,7 +240,7 @@ Minimal example (`validations/base-sc.json`):
 
 ### Generate a validation file from a Foundry run
 
-Use `scripts/genValidationFile.ts` to transform a Foundry run (which emits a `stateDiff.json` file in your task directory) into the validation JSON the app consumes.
+Use `scripts/genValidationFile.ts` to transform a Foundry run (which emits a `stateDiff.json` file in `active/evm`) into the validation JSON the app consumes.
 
 Requirements:
 
@@ -274,9 +267,9 @@ General usage (tsx):
 npm ci
 npx tsx scripts/genValidationFile.ts \
   --rpc-url https://mainnet.example \
-  --workdir <network>/<YYYY-MM-DD-task> \
+  --workdir active/evm \
   --forge-cmd "forge script <path>:<Contract> --sig 'run()' --sender 0xabc..." \
-  --out <network>/<YYYY-MM-DD-task>/validations/<user-type>.json
+  --out active/evm/tasks/<task-id>/config/<network>/validations/<user-type>.json
 ```
 
 Alternative (bun):
@@ -286,9 +279,9 @@ Alternative (bun):
 npm ci
 bun run scripts/genValidationFile.ts \
   --rpc-url https://mainnet.example \
-  --workdir <network>/<YYYY-MM-DD-task> \
+  --workdir active/evm \
   --forge-cmd "forge script <path>:<Contract> --sig 'run()' --sender 0xabc..." \
-  --out <network>/<YYYY-MM-DD-task>/validations/<user-type>.json
+  --out active/evm/tasks/<task-id>/config/<network>/validations/<user-type>.json
 ```
 
 Example from a Makefile (variables expanded in your environment):
@@ -297,15 +290,15 @@ Example from a Makefile (variables expanded in your environment):
 cd "$SIGNER_TOOL_PATH" && \
   npm ci && \
   bun run scripts/genValidationFile.ts --rpc-url "$L1_RPC_URL" \
-    --workdir .. \
+    --workdir ../active/evm \
     --forge-cmd 'forge script --rpc-url "$L1_RPC_URL" SwapOwner --sig "sign()" --sender "$SENDER"' \
-    --out ../validations/test.json
+    --out ../active/evm/tasks/2026-06-18-beryl-1/config/mainnet/validations/test.json
 ```
 
 Notes:
 
 - Quote the entire `--forge-cmd` so that inner quotes for `--sig` are preserved by your shell. On macOS/Linux, prefer single quotes around the whole command and double quotes inside for signatures/addresses.
-- `--workdir` typically points to the task directory (e.g., `mainnet/2025-06-04-upgrade-foo`). If you keep this repo inside the task repo root, `..` will refer to the task directory when running from `task-signing-tool/`.
+- `--workdir` should point to `active/evm` so generated validation commands match the app's simulation cwd.
 - If `--out` is omitted, the JSON is printed to stdout.
 
 ### Task Origin Signing
@@ -314,7 +307,7 @@ Use `scripts/genTaskOriginSig.ts` to sign task folders for origin validation. Ta
 
 #### Signature files
 
-When task origin validation is enabled, three signature files must exist in `<network>/signatures/<task-name>/`:
+When task origin validation is enabled, three signature files must exist in `active/evm/tasks/<task-id>/config/<network>/signatures/`:
 
 - **Task Creator**: `creator-signature.json` — common name is the email of the task author (e.g., `alice@example.com`)
 - **Base Facilitator**: `base-facilitator-signature.json` — common name is `base-facilitators` (group)
@@ -322,7 +315,7 @@ When task origin validation is enabled, three signature files must exist in `<ne
 
 The **common name** is extracted from the signer's X.509 certificate Subject Alternative Name (SAN). For task creators, this is their email address. For facilitators, it is the group name they belong to.
 
-Signatures are stored separately from task directories to ensure the tarball content remains unchanged after signing.
+Signatures are verified over `active/evm/`, matching the directory used for simulation. Store signatures under `active/evm/tasks/<task-id>/config/<network>/signatures/`; the signer tool excludes nested `signatures/` directories from the deterministic tarball so signing does not change the attested payload.
 
 #### Requirements
 
@@ -339,7 +332,7 @@ The script supports four commands:
 
 #### Flags
 
-- `--task-folder, -t`: **Required.** Path to the task folder to sign/verify
+- `--task-folder, -t`: **Required.** Path to the active EVM folder to sign/verify
 - `--signature-path, -p`: Directory to store/read signatures (defaults to task folder)
 - `--facilitator, -f`: Facilitator type: `base` or `security-council`. Omit to sign/verify as task creator
 - `--common-name, -c`: Common name for verification (required for task creator verification)
@@ -359,8 +352,8 @@ npx tsx scripts/genTaskOriginSig.ts --help
 ```bash
 npm ci
 npx tsx scripts/genTaskOriginSig.ts sign \
-  --task-folder <path>/<network>/<task> \
-  --signature-path <path>/<network>/signatures/<task>
+  --task-folder active/evm \
+  --signature-path active/evm/tasks/2026-06-18-beryl-1/config/mainnet/signatures
 ```
 
 **Sign as Base facilitator:**
@@ -368,8 +361,8 @@ npx tsx scripts/genTaskOriginSig.ts sign \
 ```bash
 npm ci
 npx tsx scripts/genTaskOriginSig.ts sign \
-  --task-folder <path>/<network>/<task> \
-  --signature-path <path>/<network>/signatures/<task> \
+  --task-folder active/evm \
+  --signature-path active/evm/tasks/2026-06-18-beryl-1/config/mainnet/signatures \
   --facilitator base
 ```
 
@@ -378,8 +371,8 @@ npx tsx scripts/genTaskOriginSig.ts sign \
 ```bash
 npm ci
 npx tsx scripts/genTaskOriginSig.ts verify \
-  --task-folder <path>/<network>/<task> \
-  --signature-path <path>/<network>/signatures/<task> \
+  --task-folder active/evm \
+  --signature-path active/evm/tasks/2026-06-18-beryl-1/config/mainnet/signatures \
   --common-name alice@example.com
 ```
 
@@ -423,12 +416,12 @@ When you enable `--estimate-l2-gas`:
 ```bash
 npx tsx scripts/genValidationFile.ts \
   --rpc-url https://mainnet.example \
-  --workdir mainnet/2025-06-04-my-l2-deposit \
+  --workdir active/evm \
   --forge-cmd "forge script script/MyDeposit.s.sol:MyDeposit --sig 'run()' --sender 0xabc --json" \
   --estimate-l2-gas \
   --l2-rpc-url https://base-mainnet.example \
   --l2-gas-buffer 25 \
-  --out validations/base-sc.json
+  --out active/evm/tasks/<task-id>/config/<network>/validations/base-sc.json
 ```
 
 #### Validation File Output

--- a/src/app/api/install-deps/route.ts
+++ b/src/app/api/install-deps/route.ts
@@ -31,12 +31,11 @@ export async function POST(req: NextRequest) {
     }
 
     const actualNetwork = network.toLowerCase();
+    const actualUpgradeId = String(upgradeId);
     const shouldForceInstall = Boolean(forceInstall);
 
-    // Validate inputs to prevent path traversal attacks
-    // Only allow alphanumeric characters, hyphens, and underscores
     const safePathPattern = /^[a-zA-Z0-9_-]+$/;
-    if (!safePathPattern.test(actualNetwork) || !safePathPattern.test(upgradeId)) {
+    if (!safePathPattern.test(actualNetwork) || !safePathPattern.test(actualUpgradeId)) {
       return NextResponse.json(
         {
           error:
@@ -46,9 +45,9 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // Construct the path to the upgrade folder and lib subdirectory
     const contractDeploymentsPath = findContractDeploymentsRoot();
-    const upgradePath = path.join(contractDeploymentsPath, actualNetwork, upgradeId);
+    const upgradePath = path.join(contractDeploymentsPath, 'active', 'evm');
+    const taskPath = path.join(upgradePath, 'tasks', actualUpgradeId);
 
     // Verify the resolved path is within the allowed directory
     let resolvedUpgradePath: string;
@@ -59,12 +58,20 @@ export async function POST(req: NextRequest) {
     }
 
     const libPath = path.join(resolvedUpgradePath, 'lib');
+    const resolvedTaskPath = assertWithinDir(taskPath, contractDeploymentsPath);
 
-    // Check if the upgrade folder exists
     const upgradePathExists = await pathExists(resolvedUpgradePath);
     if (!upgradePathExists) {
       return NextResponse.json(
-        { error: `Upgrade folder not found: ${network}/${upgradeId}` },
+        { error: `Task folder not found: ${path.relative(contractDeploymentsPath, upgradePath)}` },
+        { status: 404 }
+      );
+    }
+
+    const taskPathExists = await pathExists(resolvedTaskPath);
+    if (!taskPathExists) {
+      return NextResponse.json(
+        { error: `Task folder not found: ${path.relative(contractDeploymentsPath, taskPath)}` },
         { status: 404 }
       );
     }
@@ -72,11 +79,11 @@ export async function POST(req: NextRequest) {
     const libExistsBeforeInstall = await pathExists(libPath);
 
     if (!shouldForceInstall && libExistsBeforeInstall) {
-      console.log(`Deps already installed for ${actualNetwork}/${upgradeId}; skipping.`);
+      console.log(`Deps already installed for ${actualNetwork}/${actualUpgradeId}; skipping.`);
       return NextResponse.json(
         {
           success: true,
-          message: `Dependencies already installed for ${actualNetwork}/${upgradeId}`,
+          message: `Dependencies already installed for ${actualNetwork}/${actualUpgradeId}`,
           libExists: true,
           installed: false,
           depsInstalled: false,
@@ -88,17 +95,16 @@ export async function POST(req: NextRequest) {
     }
 
     console.log(
-      `Installing dependencies for ${actualNetwork}/${upgradeId} (cwd: ${resolvedUpgradePath})`
+      `Installing dependencies for ${actualNetwork}/${actualUpgradeId} (cwd: ${resolvedUpgradePath})`
     );
 
-    // Run make deps in the upgrade folder
     const { stdout, stderr } = await execAsync('make deps', {
       cwd: resolvedUpgradePath,
       timeout: INSTALL_DEPS_TIMEOUT_MS,
       env: process.env,
     });
 
-    console.log(`Dependencies installed for ${actualNetwork}/${upgradeId}`);
+    console.log(`Dependencies installed for ${actualNetwork}/${actualUpgradeId}`);
 
     // Verify that lib folder was created
     const libExistsAfterInstall = await pathExists(libPath);
@@ -106,7 +112,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json(
       {
         success: true,
-        message: `Dependencies installed successfully for ${actualNetwork}/${upgradeId}`,
+        message: `Dependencies installed successfully for ${actualNetwork}/${actualUpgradeId}`,
         libExists: libExistsAfterInstall,
         installed: true,
         depsInstalled: true,

--- a/src/app/api/upgrade-config/__tests__/route.test.ts
+++ b/src/app/api/upgrade-config/__tests__/route.test.ts
@@ -54,65 +54,52 @@ describe('GET /api/upgrade-config', () => {
 
   describe('missing parameters', () => {
     it('returns 400 when network is missing', async () => {
-      const res = await GET(createRequest({ upgradeId: 'test' }));
+      const res = await GET(createRequest({ upgradeId: '2026-06-18-beryl-1' }));
       expect(res.status).toBe(400);
       const body = await res.json();
-      expect(body.error).toMatch(/missing required parameters/i);
+      expect(body.error).toMatch(/missing required parameter/i);
     });
 
     it('returns 400 when upgradeId is missing', async () => {
       const res = await GET(createRequest({ network: 'mainnet' }));
       expect(res.status).toBe(400);
       const body = await res.json();
-      expect(body.error).toMatch(/missing required parameters/i);
-    });
-
-    it('returns 400 when both are missing', async () => {
-      const res = await GET(createRequest({}));
-      expect(res.status).toBe(400);
-      const body = await res.json();
-      expect(body.error).toMatch(/missing required parameters/i);
+      expect(body.error).toMatch(/missing required parameter/i);
     });
   });
 
   describe('path traversal prevention', () => {
     it('returns 400 when network contains ".."', async () => {
-      const res = await GET(createRequest({ network: '..', upgradeId: 'test' }));
+      const res = await GET(createRequest({ network: '..', upgradeId: '2026-06-18-beryl-1' }));
       expect(res.status).toBe(400);
       const body = await res.json();
-      expect(body.error).toMatch(/invalid network or upgradeId/i);
+      expect(body.error).toMatch(/invalid network/i);
     });
 
     it('returns 400 when network contains "/"', async () => {
-      const res = await GET(createRequest({ network: 'foo/bar', upgradeId: 'test' }));
+      const res = await GET(createRequest({ network: 'foo/bar', upgradeId: '2026-06-18-beryl-1' }));
       expect(res.status).toBe(400);
       const body = await res.json();
-      expect(body.error).toMatch(/invalid network or upgradeId/i);
-    });
-
-    it('returns 400 when upgradeId contains ".."', async () => {
-      const res = await GET(createRequest({ network: 'mainnet', upgradeId: '..' }));
-      expect(res.status).toBe(400);
-      const body = await res.json();
-      expect(body.error).toMatch(/invalid network or upgradeId/i);
+      expect(body.error).toMatch(/invalid network/i);
     });
 
     it('returns 400 when network contains spaces', async () => {
-      const res = await GET(createRequest({ network: 'main net', upgradeId: 'test' }));
+      const res = await GET(
+        createRequest({ network: 'main net', upgradeId: '2026-06-18-beryl-1' })
+      );
       expect(res.status).toBe(400);
       const body = await res.json();
-      expect(body.error).toMatch(/invalid network or upgradeId/i);
-    });
-
-    it('returns 400 when upgradeId contains "@"', async () => {
-      const res = await GET(createRequest({ network: 'mainnet', upgradeId: 'test@1' }));
-      expect(res.status).toBe(400);
-      const body = await res.json();
-      expect(body.error).toMatch(/invalid network or upgradeId/i);
+      expect(body.error).toMatch(/invalid network/i);
     });
 
     it('returns 400 when network contains "." (single dot)', async () => {
-      const res = await GET(createRequest({ network: '.', upgradeId: 'test' }));
+      const res = await GET(createRequest({ network: '.', upgradeId: '2026-06-18-beryl-1' }));
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/invalid network/i);
+    });
+    it('returns 400 when upgradeId contains path separators', async () => {
+      const res = await GET(createRequest({ network: 'mainnet', upgradeId: 'foo/bar' }));
       expect(res.status).toBe(400);
       const body = await res.json();
       expect(body.error).toMatch(/invalid network or upgradeId/i);
@@ -120,20 +107,17 @@ describe('GET /api/upgrade-config', () => {
   });
 
   describe('valid safe characters', () => {
-    it('accepts hyphens (e.g., "op-mainnet")', async () => {
-      const res = await GET(createRequest({ network: 'op-mainnet', upgradeId: 'test' }));
-      expect(res.status).toBe(200);
-    });
-
-    it('accepts underscores (e.g., "upgrade_1")', async () => {
-      const res = await GET(createRequest({ network: 'mainnet', upgradeId: 'upgrade_1' }));
+    it('accepts hyphens in network names', async () => {
+      const res = await GET(
+        createRequest({ network: 'op-mainnet', upgradeId: '2026-06-18-beryl-1' })
+      );
       expect(res.status).toBe(200);
     });
   });
 
   describe('happy path', () => {
     it('returns 200 with config options', async () => {
-      const res = await GET(createRequest({ network: 'mainnet', upgradeId: 'test' }));
+      const res = await GET(createRequest({ network: 'mainnet', upgradeId: '2026-06-18-beryl-1' }));
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.configOptions).toHaveLength(1);
@@ -148,7 +132,7 @@ describe('GET /api/upgrade-config', () => {
     it('returns 200 with empty array on ENOENT', async () => {
       const enoentError = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
       mockReaddir.mockRejectedValue(enoentError);
-      const res = await GET(createRequest({ network: 'mainnet', upgradeId: 'test' }));
+      const res = await GET(createRequest({ network: 'mainnet', upgradeId: '2026-06-18-beryl-1' }));
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.configOptions).toEqual([]);
@@ -158,7 +142,7 @@ describe('GET /api/upgrade-config', () => {
   describe('post-validation', () => {
     it('returns 500 on unexpected fs errors', async () => {
       mockReaddir.mockRejectedValue(new Error('Unexpected disk error'));
-      const res = await GET(createRequest({ network: 'mainnet', upgradeId: 'test' }));
+      const res = await GET(createRequest({ network: 'mainnet', upgradeId: '2026-06-18-beryl-1' }));
       expect(res.status).toBe(500);
       const body = await res.json();
       expect(body.error).toMatch(/failed to fetch upgrade configuration/i);
@@ -167,7 +151,7 @@ describe('GET /api/upgrade-config', () => {
 
   describe('does not call fs', () => {
     it('readdir not called when validation rejects', async () => {
-      await GET(createRequest({ network: '..', upgradeId: 'test' }));
+      await GET(createRequest({ network: '..', upgradeId: '2026-06-18-beryl-1' }));
       expect(mockReaddir).not.toHaveBeenCalled();
       expect(mockFindContractDeploymentsRoot).not.toHaveBeenCalled();
     });

--- a/src/app/api/upgrade-config/route.ts
+++ b/src/app/api/upgrade-config/route.ts
@@ -23,7 +23,6 @@ export async function GET(req: NextRequest) {
     );
   }
 
-  // Validate inputs to prevent path traversal attacks
   const safePathPattern = /^[a-zA-Z0-9_-]+$/;
   if (!safePathPattern.test(network) || !safePathPattern.test(upgradeId)) {
     return NextResponse.json(
@@ -38,8 +37,12 @@ export async function GET(req: NextRequest) {
   const contractDeploymentsRoot = findContractDeploymentsRoot();
   const validationsJoinedPath = path.join(
     contractDeploymentsRoot,
-    network,
+    'active',
+    'evm',
+    'tasks',
     upgradeId,
+    'config',
+    network,
     'validations'
   );
 
@@ -89,10 +92,9 @@ export async function GET(req: NextRequest) {
     );
 
     console.log(
-      'Found %d config options for %s/%s:',
+      'Found %d config options for %s:',
       configOptions.length,
-      network,
-      upgradeId,
+      `${network}/${upgradeId}`,
       configOptions.map(c => c.displayName)
     );
 

--- a/src/app/api/upgrades/__tests__/route.test.ts
+++ b/src/app/api/upgrades/__tests__/route.test.ts
@@ -64,7 +64,6 @@ describe('GET /api/upgrades', () => {
     expect(body).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          id: '2025-08-01-upgrade-qux',
           network: NetworkType.Zeronet,
           status: TaskStatus.ReadyToSign,
         }),

--- a/src/app/api/upgrades/route.ts
+++ b/src/app/api/upgrades/route.ts
@@ -20,9 +20,10 @@ export function GET(req: NextRequest) {
             network: network,
           }));
       });
-      // Sort by date (most recent first)
       return NextResponse.json(
-        allReadyToSignTasks.sort((a, b) => b.id.localeCompare(a.id)),
+        allReadyToSignTasks.sort(
+          (a, b) => b.date.localeCompare(a.date) || b.id.localeCompare(a.id)
+        ),
         { status: 200 }
       );
     }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react';
 import {
+  NetworkSelection,
+  NetworkSummary,
   UpgradeSelection,
   UserSelection,
   ValidationResults,
@@ -12,13 +14,16 @@ import {
 } from '@/components';
 import { PageShell, StepIndicator } from '@/components/ui';
 import { NetworkType, ValidationData, Upgrade } from '@/lib/types';
+import { getUpgradeForNetwork, TaskOption } from '@/lib/task-selection';
 import { ConfigOption } from '@/components/UserSelection';
 import { LedgerSigningResult } from '@/lib/ledger-signing';
 
-type Step = 'upgrade' | 'user' | 'validation' | 'ledger' | 'signing';
+type Step = 'upgrade' | 'network' | 'user' | 'validation' | 'ledger' | 'signing';
+type StepStatus = 'current' | 'completed' | 'pending';
 
 const STEP_LAYOUT_WIDTH: Record<Step, string> = {
   upgrade: 'max-w-4xl',
+  network: 'max-w-3xl',
   user: 'max-w-3xl',
   validation: 'max-w-[1200px]',
   ledger: 'max-w-4xl',
@@ -29,18 +34,26 @@ export default function Home() {
   const [currentStep, setCurrentStep] = useState<Step>('upgrade');
   const [selectedUser, setSelectedUser] = useState<ConfigOption>();
   const [selectedNetwork, setSelectedNetwork] = useState<NetworkType | null>(null);
+  const [availableNetworksForTask, setAvailableNetworksForTask] = useState<NetworkType[]>([]);
   const [selectedUpgrade, setSelectedUpgrade] = useState<Upgrade | null>(null);
+  const [selectedTaskOption, setSelectedTaskOption] = useState<TaskOption | null>(null);
   const [validationData, setValidationData] = useState<ValidationData | null>(null);
   const [signingData, setSigningData] = useState<LedgerSigningResult | null>(null);
   const [userLedgerAccount, setUserLedgerAccount] = useState<number>(0);
 
-  const resetSelectionsFrom = (step: 'upgrade' | 'user') => {
+  const resetSelectionsFrom = (step: 'upgrade' | 'network' | 'user') => {
     if (step === 'upgrade') {
       setSelectedNetwork(null);
       setSelectedUpgrade(null);
+      setSelectedTaskOption(null);
+      setAvailableNetworksForTask([]);
     }
 
-    if (step === 'upgrade' || step === 'user') {
+    if (step === 'network') {
+      setSelectedNetwork(null);
+    }
+
+    if (step === 'upgrade' || step === 'network' || step === 'user') {
       setSelectedUser(undefined);
       setValidationData(null);
       setSigningData(null);
@@ -48,9 +61,34 @@ export default function Home() {
     }
   };
 
-  const handleUpgradeSelection = (upgrade: Upgrade) => {
-    setSelectedUpgrade(upgrade);
-    setSelectedNetwork(upgrade.network as NetworkType);
+  const handleUpgradeSelection = (taskOption: TaskOption) => {
+    setSelectedTaskOption(taskOption);
+    setSelectedUpgrade(taskOption.displayUpgrade);
+    setSelectedNetwork(null);
+    setSelectedUser(undefined);
+    setValidationData(null);
+    setSigningData(null);
+    setUserLedgerAccount(0);
+    setAvailableNetworksForTask(taskOption.networks);
+    setCurrentStep('network');
+  };
+
+  const handleNetworkSelection = (network: NetworkType) => {
+    const networkUpgrade = selectedTaskOption
+      ? getUpgradeForNetwork(selectedTaskOption, network)
+      : undefined;
+
+    if (!networkUpgrade) {
+      console.error(`No upgrade metadata found for ${network}`);
+      return;
+    }
+
+    setSelectedUpgrade(networkUpgrade);
+    setSelectedNetwork(network);
+    setSelectedUser(undefined);
+    setValidationData(null);
+    setSigningData(null);
+    setUserLedgerAccount(0);
     setCurrentStep('user');
   };
 
@@ -75,12 +113,24 @@ export default function Home() {
     setCurrentStep('upgrade');
   };
 
+  const handleGoToNetworkSelection = () => {
+    resetSelectionsFrom('network');
+    setCurrentStep('network');
+  };
+
   const handleGoToUserSelection = () => {
     resetSelectionsFrom('user');
     setCurrentStep('user');
   };
 
   const canEditUpgrade =
+    currentStep === 'network' ||
+    currentStep === 'user' ||
+    currentStep === 'validation' ||
+    currentStep === 'ledger' ||
+    currentStep === 'signing';
+
+  const canEditNetwork =
     currentStep === 'user' ||
     currentStep === 'validation' ||
     currentStep === 'ledger' ||
@@ -100,15 +150,20 @@ export default function Home() {
           : ((selectedUpgrade ? 'completed' : 'pending') as 'current' | 'completed' | 'pending'),
     },
     {
+      id: 'network',
+      label: 'Select Network',
+      status:
+        currentStep === 'network'
+          ? 'current'
+          : ((selectedNetwork ? 'completed' : 'pending') as StepStatus),
+    },
+    {
       id: 'user',
       label: 'Select User',
       status:
         currentStep === 'user'
           ? 'current'
-          : ((selectedUser ? 'completed' : selectedUpgrade ? 'pending' : 'pending') as
-              | 'current'
-              | 'completed'
-              | 'pending'),
+          : ((selectedUser ? 'completed' : 'pending') as StepStatus),
     },
     {
       id: 'validation',
@@ -116,10 +171,7 @@ export default function Home() {
       status:
         currentStep === 'validation'
           ? 'current'
-          : ((validationData ? 'completed' : selectedUser ? 'pending' : 'pending') as
-              | 'current'
-              | 'completed'
-              | 'pending'),
+          : ((validationData ? 'completed' : 'pending') as StepStatus),
     },
     {
       id: 'ledger',
@@ -127,16 +179,12 @@ export default function Home() {
       status:
         currentStep === 'ledger'
           ? 'current'
-          : ((signingData ? 'completed' : validationData ? 'pending' : 'pending') as
-              | 'current'
-              | 'completed'
-              | 'pending'),
+          : ((signingData ? 'completed' : 'pending') as StepStatus),
     },
     {
       id: 'signing',
       label: 'Confirmation',
-      status:
-        currentStep === 'signing' ? 'current' : ('pending' as 'current' | 'completed' | 'pending'),
+      status: currentStep === 'signing' ? 'current' : ('pending' as StepStatus),
     },
   ];
 
@@ -152,15 +200,26 @@ export default function Home() {
           />
         )}
 
+        {canEditNetwork && (
+          <NetworkSummary selectedNetwork={selectedNetwork} onChange={handleGoToNetworkSelection} />
+        )}
+
         {canEditUser && (
           <UserSummary selectedUser={selectedUser} onChange={handleGoToUserSelection} />
         )}
 
         {currentStep === 'upgrade' && (
           <UpgradeSelection
-            selectedWallet={selectedUpgrade?.id || null}
-            selectedNetwork={selectedNetwork}
+            selectedUpgradeId={selectedUpgrade?.id ?? null}
             onSelect={handleUpgradeSelection}
+          />
+        )}
+
+        {currentStep === 'network' && selectedUpgrade && (
+          <NetworkSelection
+            selectedNetwork={selectedNetwork}
+            networks={availableNetworksForTask}
+            onSelect={handleNetworkSelection}
           />
         )}
 
@@ -172,14 +231,11 @@ export default function Home() {
           />
         )}
 
-        {currentStep === 'validation' && (
+        {currentStep === 'validation' && selectedUpgrade && (
           <ValidationResults
             userType={selectedUser?.fileName || ''}
             network={selectedNetwork || ''}
-            selectedUpgrade={{
-              id: selectedUpgrade?.id || '',
-              name: selectedUpgrade?.name || '',
-            }}
+            upgradeId={selectedUpgrade.id}
             onProceedToLedgerSigning={handleProceedToLedgerSigning}
           />
         )}
@@ -198,7 +254,6 @@ export default function Home() {
             user={selectedUser}
             network={selectedNetwork || ''}
             selectedUpgrade={{
-              id: selectedUpgrade?.id || '',
               name: selectedUpgrade?.name || '',
             }}
             signingData={signingData}

--- a/src/components/NetworkSelection.tsx
+++ b/src/components/NetworkSelection.tsx
@@ -1,26 +1,75 @@
-import { Globe } from 'lucide-react';
-import { availableNetworks } from '@/lib/constants';
+import { Check, Globe } from 'lucide-react';
+import { formatNetworkName } from '@/lib/network-utils';
 import { NetworkType } from '@/lib/types';
+import { Badge } from './ui/Badge';
+import { Card } from './ui/Card';
+import { SectionHeader } from './ui/SectionHeader';
 
 interface NetworkSelectionProps {
+  selectedNetwork?: NetworkType | null;
+  networks: NetworkType[];
   onSelect: (network: NetworkType) => void;
 }
 
-export function NetworkSelection({ onSelect }: NetworkSelectionProps) {
+export function NetworkSelection({ selectedNetwork, networks, onSelect }: NetworkSelectionProps) {
+  if (networks.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center p-12 text-center min-h-[320px] bg-white rounded-2xl border border-[var(--cds-border)] border-dashed">
+        <div className="h-12 w-12 rounded-full bg-gray-50 flex items-center justify-center mb-4">
+          <Globe size={24} className="text-[var(--cds-text-tertiary)]" aria-hidden="true" />
+        </div>
+        <h3 className="text-lg font-semibold text-[var(--cds-text-primary)]">No networks found</h3>
+        <p className="text-sm text-[var(--cds-text-secondary)] mt-1">
+          This task does not have any ready-to-sign network configs.
+        </p>
+      </div>
+    );
+  }
+
   return (
-    <div className="text-center">
-      <h2 className="mb-8 text-2xl font-semibold text-gray-700">Select Network</h2>
-      <div className="flex flex-col gap-3">
-        {availableNetworks.map(option => (
-          <button
-            key={option}
-            onClick={() => onSelect(option)}
-            className="flex w-full items-center justify-center gap-2 rounded-xl border border-gray-200 bg-white p-5 text-base font-medium text-gray-700 shadow-sm transition-transform duration-200 hover:-translate-y-0.5 hover:border-gray-300 hover:bg-gray-50 hover:shadow-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-400 cursor-pointer"
-          >
-            <Globe size={20} aria-hidden="true" />{' '}
-            {option.charAt(0).toUpperCase() + option.slice(1)}
-          </button>
-        ))}
+    <div className="w-full animate-fade-in">
+      <SectionHeader title="Select Network" description="Choose which network config to sign." />
+
+      <div className="space-y-4">
+        {networks.map(network => {
+          const isSelected = selectedNetwork === network;
+
+          return (
+            <Card
+              key={network}
+              interactive
+              selected={isSelected}
+              onClick={() => onSelect(network)}
+              className="relative group"
+            >
+              <div className="flex items-center justify-between gap-6">
+                <div className="flex items-center gap-4 min-w-0">
+                  <div className="h-10 w-10 rounded-full bg-blue-100 text-[var(--cds-primary)] flex items-center justify-center shrink-0">
+                    <Globe size={20} aria-hidden="true" />
+                  </div>
+                  <div className="min-w-0">
+                    <h3 className="text-lg font-semibold text-[var(--cds-text-primary)] truncate">
+                      {formatNetworkName(network)}
+                    </h3>
+                    <Badge
+                      variant="neutral"
+                      size="sm"
+                      className="mt-1 uppercase tracking-wider text-[10px] font-bold"
+                    >
+                      {network}
+                    </Badge>
+                  </div>
+                </div>
+
+                {isSelected && (
+                  <div className="h-6 w-6 rounded-full bg-[var(--cds-primary)] text-white flex items-center justify-center shrink-0">
+                    <Check size={14} strokeWidth={3} aria-hidden="true" />
+                  </div>
+                )}
+              </div>
+            </Card>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/NetworkSummary.tsx
+++ b/src/components/NetworkSummary.tsx
@@ -1,0 +1,44 @@
+import { Globe } from 'lucide-react';
+import { formatNetworkName } from '@/lib/network-utils';
+import { NetworkType } from '@/lib/types';
+import { Badge } from './ui/Badge';
+import { Button } from './ui/Button';
+import { Card } from './ui/Card';
+
+interface NetworkSummaryProps {
+  selectedNetwork: NetworkType | null;
+  onChange?: () => void;
+}
+
+export function NetworkSummary({ selectedNetwork, onChange }: NetworkSummaryProps) {
+  if (!selectedNetwork) return null;
+
+  return (
+    <Card padding="sm" className="mb-8 bg-gray-50/50 border-dashed">
+      <div className="flex items-center justify-between p-4 gap-4">
+        <div className="flex items-center gap-4">
+          <div className="h-10 w-10 rounded-full bg-blue-100 text-[var(--cds-primary)] flex items-center justify-center">
+            <Globe size={20} aria-hidden="true" />
+          </div>
+          <div>
+            <h3 className="font-semibold text-[var(--cds-text-primary)]">
+              {formatNetworkName(selectedNetwork)}
+            </h3>
+            <Badge
+              variant="neutral"
+              size="sm"
+              className="mt-1 uppercase tracking-wider text-[10px]"
+            >
+              {selectedNetwork}
+            </Badge>
+          </div>
+        </div>
+        {onChange && (
+          <Button variant="ghost" size="sm" onClick={onChange} className="shrink-0">
+            Change
+          </Button>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/src/components/SigningConfirmation.tsx
+++ b/src/components/SigningConfirmation.tsx
@@ -10,7 +10,6 @@ interface SigningConfirmationProps {
   user?: ConfigOption;
   network: string;
   selectedUpgrade: {
-    id: string;
     name: string;
   };
   signingData?: LedgerSigningResult | null;

--- a/src/components/UpgradeSelection.tsx
+++ b/src/components/UpgradeSelection.tsx
@@ -1,5 +1,6 @@
+import { groupUpgradesByTask, TaskOption } from '@/lib/task-selection';
 import { TaskStatus, Upgrade, ExecutionLink } from '@/lib/types';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Card } from './ui/Card';
@@ -13,14 +14,12 @@ const STATUS_VARIANT_MAP: Record<TaskStatus, 'success' | 'warning' | 'neutral'> 
 };
 
 interface UpgradeSelectionProps {
-  selectedWallet: string | null;
-  selectedNetwork: string | null;
-  onSelect: (upgrade: Upgrade) => void;
+  selectedUpgradeId: string | null;
+  onSelect: (taskOption: TaskOption) => void;
 }
 
 export const UpgradeSelection: React.FC<UpgradeSelectionProps> = ({
-  selectedWallet,
-  selectedNetwork,
+  selectedUpgradeId,
   onSelect,
 }) => {
   const [upgradeOptions, setUpgradeOptions] = useState<Upgrade[]>([]);
@@ -65,6 +64,8 @@ export const UpgradeSelection: React.FC<UpgradeSelectionProps> = ({
     return () => abortControllerRef.current?.abort();
   }, [fetchUpgrades]);
 
+  const taskOptions = useMemo(() => groupUpgradesByTask(upgradeOptions), [upgradeOptions]);
+
   if (loading) {
     return (
       <div className="flex flex-col items-center justify-center p-12 text-center min-h-[400px]">
@@ -105,7 +106,7 @@ export const UpgradeSelection: React.FC<UpgradeSelectionProps> = ({
     );
   }
 
-  if (upgradeOptions.length === 0) {
+  if (taskOptions.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center p-12 text-center min-h-[400px] bg-white rounded-2xl border border-[var(--cds-border)] border-dashed">
         <div className="h-12 w-12 rounded-full bg-gray-50 flex items-center justify-center mb-4">
@@ -136,28 +137,32 @@ export const UpgradeSelection: React.FC<UpgradeSelectionProps> = ({
       <SectionHeader title="Select Task" description="Choose a task to validate and sign." />
 
       <div className="space-y-4">
-        {upgradeOptions.map(option => {
-          const isSelected = selectedWallet === option.id && selectedNetwork === option.network;
+        {taskOptions.map(taskOption => {
+          const { displayUpgrade: option, networks } = taskOption;
+          const isSelected = selectedUpgradeId === option.id;
           const isExpanded = !!expandedCards[option.id];
 
           return (
             <Card
-              key={`${option.network}-${option.id}`}
+              key={option.id}
               interactive
               selected={isSelected}
-              onClick={() => onSelect(option)}
+              onClick={() => onSelect(taskOption)}
               className="relative group"
             >
               <div className="flex items-start justify-between gap-6">
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-3 mb-2">
-                    <Badge
-                      variant="neutral"
-                      size="sm"
-                      className="uppercase tracking-wider text-[10px] font-bold"
-                    >
-                      {option.network}
-                    </Badge>
+                    {networks.map(network => (
+                      <Badge
+                        key={network}
+                        variant="neutral"
+                        size="sm"
+                        className="uppercase tracking-wider text-[10px] font-bold"
+                      >
+                        {network}
+                      </Badge>
+                    ))}
                     <span className="text-xs text-[var(--cds-text-tertiary)]">{option.date}</span>
                   </div>
 

--- a/src/components/UserSelection.tsx
+++ b/src/components/UserSelection.tsx
@@ -22,7 +22,6 @@ export function UserSelection({ network, upgradeId, onSelect }: UserSelectionPro
   const [loadingUsers, setLoadingUsers] = useState(false);
   const [error, setError] = useState<string>('');
 
-  // Fetch available users when network and upgradeId change
   useEffect(() => {
     const resetState = () => {
       setAvailableUsers([]);

--- a/src/components/ValidationResults.tsx
+++ b/src/components/ValidationResults.tsx
@@ -105,10 +105,7 @@ const TaskOriginSkippedCard: React.FC = () => {
 interface ValidationResultsProps {
   userType: string;
   network: string;
-  selectedUpgrade: {
-    id: string;
-    name: string;
-  };
+  upgradeId: string;
   onProceedToLedgerSigning: (validationResult: ValidationData) => void;
 }
 
@@ -131,7 +128,7 @@ const getIcon = (iconName: string, size: number = 24, className?: string) => {
 export const ValidationResults: React.FC<ValidationResultsProps> = ({
   userType,
   network,
-  selectedUpgrade,
+  upgradeId,
   onProceedToLedgerSigning,
 }) => {
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -145,7 +142,7 @@ export const ValidationResults: React.FC<ValidationResultsProps> = ({
     runValidation,
   } = useValidationRunner({
     network,
-    upgradeId: selectedUpgrade.id,
+    upgradeId,
     userType,
   });
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,8 @@
 export { ComparisonCard } from './ComparisonCard';
 export { HighlightedText } from './HighlightedText';
 export { LedgerSigning } from './LedgerSigning';
+export { NetworkSelection } from './NetworkSelection';
+export { NetworkSummary } from './NetworkSummary';
 export { SelectionSummary } from './SelectionSummary';
 export { SigningConfirmation } from './SigningConfirmation';
 export { UpgradeSelection } from './UpgradeSelection';

--- a/src/components/ui/StepIndicator.tsx
+++ b/src/components/ui/StepIndicator.tsx
@@ -12,7 +12,10 @@ export const StepIndicator = ({ steps }: StepIndicatorProps) => {
   return (
     <div className="flex items-center justify-center w-full py-8">
       <nav aria-label="Progress">
-        <ol role="list" className="flex items-center space-x-8">
+        <ol
+          role="list"
+          className="flex flex-wrap items-center justify-center gap-x-6 gap-y-4 sm:gap-x-8"
+        >
           {steps.map((step, stepIdx) => (
             <li key={step.id} className="relative">
               {step.status === 'completed' ? (

--- a/src/lib/__tests__/deployments.test.ts
+++ b/src/lib/__tests__/deployments.test.ts
@@ -1,4 +1,28 @@
-import { normalizeUrl } from '../deployments';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import {
+  getUpgradeOptions,
+  normalizeUrl,
+  resetContractDeploymentsRootCacheForTests,
+} from '../deployments';
+import { NetworkType, TaskStatus } from '../types';
+
+let originalCwd: string;
+let tempDir: string;
+
+beforeEach(async () => {
+  originalCwd = process.cwd();
+  resetContractDeploymentsRootCacheForTests();
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'deployments-'));
+});
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  resetContractDeploymentsRootCacheForTests();
+  await fs.rm(tempDir, { recursive: true, force: true });
+});
 
 describe('normalizeUrl', () => {
   describe('valid URLs', () => {
@@ -81,5 +105,111 @@ describe('normalizeUrl', () => {
       const url = 'https://user:pass@example.com/path';
       expect(normalizeUrl(url)).toBe(url);
     });
+  });
+});
+
+describe('getUpgradeOptions', () => {
+  it('discovers active task folders without root-level network folders', async () => {
+    const toolDir = path.join(tempDir, 'task-signing-tool');
+    const taskPath = path.join(tempDir, 'active', 'evm', 'tasks', '2026-06-19-upgrade');
+    await fs.mkdir(path.join(taskPath, 'config', 'mainnet', 'validations'), { recursive: true });
+    await fs.mkdir(toolDir, { recursive: true });
+    await fs.writeFile(
+      path.join(taskPath, 'README.md'),
+      [
+        '# 2026-06-19 Verifier Hash Update',
+        '',
+        'Status: READY TO SIGN',
+        '',
+        '## Description',
+        '',
+        'Update verifier hashes for mainnet.',
+      ].join('\n')
+    );
+    process.chdir(toolDir);
+
+    const upgrades = getUpgradeOptions(NetworkType.Mainnet);
+
+    expect(upgrades).toEqual([
+      expect.objectContaining({
+        id: '2026-06-19-upgrade',
+        name: '2026-06-19 Verifier Hash Update',
+        date: '2026-06-19',
+        network: NetworkType.Mainnet,
+        status: TaskStatus.ReadyToSign,
+        description: 'Update verifier hashes for mainnet.',
+      }),
+    ]);
+  });
+
+  it('returns all active task folders that have validations for the selected network', async () => {
+    const toolDir = path.join(tempDir, 'task-signing-tool');
+    await fs.mkdir(
+      path.join(
+        tempDir,
+        'active',
+        'evm',
+        'tasks',
+        '2026-06-18-beryl-1',
+        'config',
+        'mainnet',
+        'validations'
+      ),
+      { recursive: true }
+    );
+    await fs.mkdir(
+      path.join(
+        tempDir,
+        'active',
+        'evm',
+        'tasks',
+        '2026-06-18-beryl-2',
+        'config',
+        'mainnet',
+        'validations'
+      ),
+      { recursive: true }
+    );
+    await fs.mkdir(
+      path.join(
+        tempDir,
+        'active',
+        'evm',
+        'tasks',
+        '2026-06-18-beryl-2',
+        'config',
+        'zeronet',
+        'validations'
+      ),
+      { recursive: true }
+    );
+    await fs.mkdir(toolDir, { recursive: true });
+    process.chdir(toolDir);
+
+    const upgrades = getUpgradeOptions(NetworkType.Mainnet);
+
+    expect(upgrades.map(upgrade => upgrade.id)).toEqual([
+      '2026-06-18-beryl-2',
+      '2026-06-18-beryl-1',
+    ]);
+  });
+
+  it('does not discover old root-level network tasks', async () => {
+    const toolDir = path.join(tempDir, 'task-signing-tool');
+    await fs.mkdir(path.join(tempDir, 'mainnet', '2026-06-19-upgrade', 'validations'), {
+      recursive: true,
+    });
+    await fs.mkdir(toolDir, { recursive: true });
+    await fs.writeFile(
+      path.join(tempDir, 'mainnet', '2026-06-19-upgrade', 'README.md'),
+      ['# Upgrade', '', 'Status: READY TO SIGN', '', '## Description', '', 'Legacy task.'].join(
+        '\n'
+      )
+    );
+    process.chdir(toolDir);
+
+    const upgrades = getUpgradeOptions(NetworkType.Mainnet);
+
+    expect(upgrades).toEqual([]);
   });
 });

--- a/src/lib/__tests__/network-utils.test.ts
+++ b/src/lib/__tests__/network-utils.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from '@jest/globals';
+import { formatNetworkName } from '../network-utils';
+
+describe('formatNetworkName', () => {
+  it('formats dashed network ids for display', () => {
+    expect(formatNetworkName('mainnet')).toBe('Mainnet');
+    expect(formatNetworkName('sepolia-alpha')).toBe('Sepolia Alpha');
+  });
+});

--- a/src/lib/__tests__/task-selection.test.ts
+++ b/src/lib/__tests__/task-selection.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from '@jest/globals';
+import { getUpgradeForNetwork, groupUpgradesByTask } from '../task-selection';
+import { NetworkType, TaskStatus, Upgrade } from '../types';
+
+function upgrade({
+  id,
+  network,
+  ...overrides
+}: Partial<Upgrade> & Pick<Upgrade, 'id' | 'network'>): Upgrade {
+  return {
+    id,
+    name: `${network} name`,
+    description: `${network} description`,
+    date: '2026-06-18',
+    network,
+    status: TaskStatus.ReadyToSign,
+    ...overrides,
+  };
+}
+
+describe('task selection helpers', () => {
+  it('groups upgrades by task id and sorts the available networks', () => {
+    const options = groupUpgradesByTask([
+      upgrade({ id: '2026-06-18-beryl-1', network: NetworkType.Zeronet }),
+      upgrade({ id: '2026-06-18-beryl-1', network: NetworkType.Mainnet }),
+      upgrade({ id: '2026-06-19-jasper-1', network: NetworkType.Sepolia }),
+    ]);
+
+    expect(options).toHaveLength(2);
+    expect(options[0]).toMatchObject({
+      id: '2026-06-18-beryl-1',
+      networks: [NetworkType.Mainnet, NetworkType.Zeronet],
+    });
+    expect(options[1]).toMatchObject({
+      id: '2026-06-19-jasper-1',
+      networks: [NetworkType.Sepolia],
+    });
+  });
+
+  it('keeps network-specific metadata for the selected network', () => {
+    const mainnetUpgrade = upgrade({
+      id: '2026-06-18-beryl-1',
+      network: NetworkType.Mainnet,
+      name: 'Mainnet title',
+      description: 'Mainnet README content',
+      status: TaskStatus.ReadyToSign,
+    });
+    const zeronetUpgrade = upgrade({
+      id: '2026-06-18-beryl-1',
+      network: NetworkType.Zeronet,
+      name: 'Zeronet title',
+      description: 'Zeronet README content',
+      status: TaskStatus.Executed,
+      executionLinks: [{ label: 'Execution', url: 'https://example.com/tx' }],
+    });
+
+    const [taskOption] = groupUpgradesByTask([mainnetUpgrade, zeronetUpgrade]);
+
+    expect(taskOption.displayUpgrade).toBe(mainnetUpgrade);
+    expect(getUpgradeForNetwork(taskOption, NetworkType.Mainnet)).toBe(mainnetUpgrade);
+    expect(getUpgradeForNetwork(taskOption, NetworkType.Zeronet)).toBe(zeronetUpgrade);
+    expect(getUpgradeForNetwork(taskOption, NetworkType.Zeronet)).toMatchObject({
+      name: 'Zeronet title',
+      description: 'Zeronet README content',
+      status: TaskStatus.Executed,
+    });
+  });
+});

--- a/src/lib/deployments.ts
+++ b/src/lib/deployments.ts
@@ -1,23 +1,34 @@
 import fs from 'fs';
 import path from 'path';
+import { formatNetworkName } from './network-utils';
 import { NetworkType, TaskStatus } from './types';
-import { availableNetworks } from './constants';
 
 let cachedRoot: string | null = null;
 
-export function findContractDeploymentsRoot(): string {
+function isDirectory(dirPath: string): boolean {
+  try {
+    return fs.statSync(dirPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+export function resetContractDeploymentsRootCacheForTests(): void {
+  cachedRoot = null;
+}
+
+function hasTaskLayout(root: string): boolean {
+  return isDirectory(path.join(root, 'active', 'evm', 'tasks'));
+}
+
+export function findContractDeploymentsRoot(startDir: string = process.cwd()): string {
   if (cachedRoot) return cachedRoot;
 
-  let currentDir = process.cwd();
+  let currentDir = startDir;
   const root = path.parse(currentDir).root;
 
   while (currentDir !== root) {
-    const hasNetworkFolders = availableNetworks.some(network => {
-      const netPath = path.join(currentDir, network);
-      return fs.existsSync(netPath) && fs.statSync(netPath).isDirectory();
-    });
-
-    if (hasNetworkFolders) {
+    if (hasTaskLayout(currentDir)) {
       cachedRoot = currentDir;
       return currentDir;
     }
@@ -25,7 +36,7 @@ export function findContractDeploymentsRoot(): string {
     currentDir = path.dirname(currentDir);
   }
 
-  // Fallback for default behavior
+  // Fallback for default behavior when the tool is cloned inside the task repo root.
   cachedRoot = path.join(process.cwd(), '..');
   return cachedRoot;
 }
@@ -54,6 +65,14 @@ function formatUpgradeName(folderName: string): string {
     .filter(Boolean)
     .map(part => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ');
+}
+
+function extractTitle(content: string): string | undefined {
+  const titleLine = content
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .find(line => /^#\s+/.test(line.trim()));
+  return titleLine?.replace(/^#\s+/, '').trim() || undefined;
 }
 
 function cleanMarkdownBlock(block: string): string {
@@ -175,60 +194,97 @@ function parseExecutionStatus(content: string): {
   }
 }
 
+function deriveDateFromContent(content: string): string | undefined {
+  const match = content.match(/\b(\d{4}-\d{2}-\d{2})\b/);
+  return match?.[1];
+}
+
 function deriveDateFromFolder(folderName: string): string {
   const match = folderName.match(/^(\d{4}-\d{2}-\d{2})/);
-  return match ? match[1] : folderName.substring(0, 10);
+  return match ? match[1] : folderName;
+}
+
+function readDeploymentInfoFromReadme(
+  baseInfo: DeploymentInfo,
+  readmePath: string,
+  options?: { useTitle?: boolean; defaultDate?: string }
+): DeploymentInfo {
+  try {
+    const content = fs.readFileSync(readmePath, 'utf-8');
+    const { status, executionLinks } = parseExecutionStatus(content);
+    return {
+      ...baseInfo,
+      name: options?.useTitle ? extractTitle(content) || baseInfo.name : baseInfo.name,
+      description: extractDescription(content),
+      date: options?.defaultDate ?? deriveDateFromContent(content) ?? baseInfo.date,
+      status,
+      executionLinks,
+    };
+  } catch (parseError) {
+    console.error(`Error parsing ${readmePath}:`, parseError);
+    return { ...baseInfo, description: DEFAULT_DESCRIPTION };
+  }
+}
+
+function getUpgradeOption(
+  contractDeploymentsPath: string,
+  taskId: string,
+  network: NetworkType
+): DeploymentInfo | undefined {
+  if (!hasTaskLayout(contractDeploymentsPath)) {
+    return undefined;
+  }
+
+  const evmPath = path.join(contractDeploymentsPath, 'active', 'evm');
+  const taskPath = path.join(evmPath, 'tasks', taskId);
+  const networkConfigPath = path.join(taskPath, 'config', network);
+  const validationsPath = path.join(networkConfigPath, 'validations');
+
+  if (!fs.existsSync(validationsPath) || !fs.statSync(validationsPath).isDirectory()) {
+    return undefined;
+  }
+
+  const baseInfo: DeploymentInfo = {
+    id: taskId,
+    name: formatUpgradeName(taskId) || `${formatNetworkName(network)} Task`,
+    description: '',
+    date: deriveDateFromFolder(taskId),
+    network,
+  };
+
+  const readmePath = [
+    path.join(networkConfigPath, 'README.md'),
+    path.join(taskPath, 'README.md'),
+    path.join(evmPath, 'README.md'),
+  ].find(filePath => fs.existsSync(filePath) && fs.statSync(filePath).isFile());
+
+  if (!readmePath) {
+    return baseInfo;
+  }
+
+  return readDeploymentInfoFromReadme(baseInfo, readmePath, {
+    useTitle: true,
+    defaultDate: deriveDateFromContent(fs.readFileSync(readmePath, 'utf-8')) ?? baseInfo.date,
+  });
 }
 
 export function getUpgradeOptions(network: NetworkType): DeploymentInfo[] {
   const contractDeploymentsPath = findContractDeploymentsRoot();
-  const networkPath = path.join(contractDeploymentsPath, network);
+  const tasksPath = path.join(contractDeploymentsPath, 'active', 'evm', 'tasks');
 
-  if (!fs.existsSync(networkPath)) {
-    console.error(`Network path does not exist: ${networkPath}`);
+  if (!isDirectory(tasksPath)) {
     return [];
   }
 
   try {
-    const folders = fs
-      .readdirSync(networkPath, { withFileTypes: true })
+    return fs
+      .readdirSync(tasksPath, { withFileTypes: true })
       .filter(dirent => dirent.isDirectory())
-      .map(dirent => dirent.name)
-      .filter(name => /^\d{4}-\d{2}-\d{2}-/.test(name));
-
-    const upgrades = folders.map(folderName => {
-      const date = deriveDateFromFolder(folderName);
-      const baseInfo: DeploymentInfo = {
-        id: folderName,
-        name: formatUpgradeName(folderName),
-        description: '',
-        date,
-        network,
-      };
-
-      const readmePath = path.join(networkPath, folderName, 'README.md');
-      if (!fs.existsSync(readmePath)) {
-        return baseInfo;
-      }
-
-      try {
-        const content = fs.readFileSync(readmePath, 'utf-8');
-        const { status, executionLinks } = parseExecutionStatus(content);
-        return {
-          ...baseInfo,
-          description: extractDescription(content),
-          status,
-          executionLinks,
-        };
-      } catch (parseError) {
-        console.error(`Error parsing ${folderName}:`, parseError);
-        return { ...baseInfo, description: DEFAULT_DESCRIPTION };
-      }
-    });
-
-    return upgrades.sort((a, b) => b.id.localeCompare(a.id));
+      .map(dirent => getUpgradeOption(contractDeploymentsPath, dirent.name, network))
+      .filter((option): option is DeploymentInfo => option !== undefined)
+      .sort((a, b) => b.id.localeCompare(a.id));
   } catch (error) {
-    console.error(`Error reading deployment folders for ${network}:`, error);
+    console.error(`Error reading active task folders for ${network}:`, error);
     return [];
   }
 }

--- a/src/lib/network-utils.ts
+++ b/src/lib/network-utils.ts
@@ -1,0 +1,7 @@
+export function formatNetworkName(network: string): string {
+  return network
+    .split('-')
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}

--- a/src/lib/task-selection.ts
+++ b/src/lib/task-selection.ts
@@ -1,0 +1,46 @@
+import { NetworkType, Upgrade } from './types';
+
+export type TaskOption = {
+  id: string;
+  displayUpgrade: Upgrade;
+  networks: NetworkType[];
+  upgradesByNetwork: Partial<Record<NetworkType, Upgrade>>;
+};
+
+export function groupUpgradesByTask(upgrades: Upgrade[]): TaskOption[] {
+  const grouped = new Map<string, TaskOption>();
+
+  for (const upgrade of upgrades) {
+    const network = upgrade.network as NetworkType;
+    const existing = grouped.get(upgrade.id);
+
+    if (existing) {
+      if (!existing.networks.includes(network)) {
+        existing.networks.push(network);
+      }
+      existing.upgradesByNetwork[network] = upgrade;
+      continue;
+    }
+
+    grouped.set(upgrade.id, {
+      id: upgrade.id,
+      displayUpgrade: upgrade,
+      networks: [network],
+      upgradesByNetwork: {
+        [network]: upgrade,
+      },
+    });
+  }
+
+  return Array.from(grouped.values()).map(option => ({
+    ...option,
+    networks: [...option.networks].sort((a, b) => a.localeCompare(b)),
+  }));
+}
+
+export function getUpgradeForNetwork(
+  taskOption: TaskOption,
+  network: NetworkType
+): Upgrade | undefined {
+  return taskOption.upgradesByNetwork[network];
+}


### PR DESCRIPTION
## Summary
- add task-first, network-second selection for active EVM tasks
- discover active task configs from active/evm/tasks/<task-id>/config/<network>/validations
- preserve network-specific task metadata after network selection
- update install-deps, upgrade-config, upgrade listing, UI summaries, and README for the active task layout

## Test plan
- npm test
- npm run build

Stacked on #179.