### PR TITLE
fix(genTaskOriginSig): use absolute paths for ottr cli certificate output

### DIFF
--- a/scripts/genTaskOriginSig.ts
+++ b/scripts/genTaskOriginSig.ts
@@ -124,9 +124,9 @@ export async function generateDeviceCertificate(
     'us-east-1',
     '--extended-key-usage=CodeSigningCertificate',
     '--certificate-path',
-    DEVICE_CERT,
+    path.join(CERT_PATH, DEVICE_CERT),
     '--private-key-path',
-    DEVICE_CERT_KEY,
+    path.join(CERT_PATH, DEVICE_CERT_KEY),
   ];
 
   // Add group flag for facilitators


### PR DESCRIPTION
In generateDeviceCertificate(), the --certificate-path and --private-key-path
    flags passed bare filenames (device-certificate.pem) to ottr-cli. Most CLI tools
    resolve relative paths from the current working directory, not from ~/.ottr/.

    However, the code immediately after reads the files from ~/.ottr/device-certificate.pem
    and ~/.ottr/device-certificate-key.pem using path.join(CERT_PATH, DEVICE_CERT).

    This mismatch causes:
    1. ENOENT errors when the files aren't found at ~/.ottr/ (if ottr-cli writes to CWD)
    2. Silent use of stale certificates from a prior run (if ~/.ottr/ files happen to exist)

    Fix: Use absolute paths path.join(CERT_PATH, DEVICE_CERT) consistently same path
    for writing and reading.