### PR TITLE
fix(path-validation): resolve symlinks in assertWithinDir

### DIFF
--- a/src/lib/path-validation.ts
+++ b/src/lib/path-validation.ts
@@ -1,13 +1,15 @@
+import fs from 'fs';
 import path from 'path';
 
 /**
  * Validates that a resolved path is within the given directory.
+ * Follows symlinks to prevent symlink-based path traversal.
  * Throws if the path escapes the directory (path traversal).
  * Returns the resolved (normalized) path.
  */
 export function assertWithinDir(targetPath: string, allowedDir: string): string {
-  const resolved = path.resolve(targetPath);
-  const dir = path.resolve(allowedDir);
+  const resolved = fs.realpathSync(targetPath);
+  const dir = fs.realpathSync(allowedDir);
   if (!resolved.startsWith(dir + path.sep) && resolved !== dir) {
     throw new Error(`Path traversal detected: ${resolved} is outside allowed directory ${dir}`);
   }


### PR DESCRIPTION
path.resolve() does not follow symbolic links. If a symlink exists inside
    the allowed directory pointing outside (e.g., deployments/mainnet/link → /etc),
    assertWithinDir passes the check but subsequent file reads access the external path.

    Replace path.resolve() with fs.realpathSync() to resolve symlinks before
    validating the path boundary. This matches the pattern already used correctly in
    task origin validate.ts (which calls fs.realpath() before assertWithinDir).

    Affected callers that now get symlink protection:
    - install-deps/route.ts:56
    - upgrade-config/route.ts:49
    - validation-service.ts:37,41,124,129
    - state-diff.ts:90