### PR TITLE
 fix(validate): add input validation for upgradeId and userType

### DIFF
--- a/src/app/api/validate/route.ts
+++ b/src/app/api/validate/route.ts
@@ -21,6 +21,15 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    // Validate inputs to prevent path traversal attacks
+    const safePathPattern = /^[a-zA-Z0-9_-]+$/;
+    if (!safePathPattern.test(upgradeId) || !safePathPattern.test(userType)) {
+      return NextResponse.json(
+        { message: 'Invalid parameters: upgradeId and userType must only contain alphanumeric characters, underscores, and hyphens' },
+        { status: 400 }
+      );
+    }
+
     const trimmedUpgradeId = upgradeId.trim();
     const trimmedUserType = userType.trim();
     const normalizedNetwork = network.trim().toLowerCase();


### PR DESCRIPTION
The validate route was missing the safe path pattern check that
    install-deps/route.ts and upgrade config/route.ts both use.

    upgrade-config/route.ts:27-28 validates both network and upgradeId
    with /^[a-zA-Z0-9_-]+$/. The validate route only checks for non-empty
    strings it passes upgradeId and userType directly into filesystem
    paths (via validation-service.ts), relying solely on assertWithinDir
    for path traversal protection.

    Add the same ^[a-zA-Z0-9_-]+$ regex validation to upgradeId and
    userType for defense-in-depth consistency with the other API routes.