### PR TITLE
fix: resolve symlinks before path validation

### DIFF
--- a/src/lib/task-origin-validate.ts
+++ b/src/lib/task-origin-validate.ts
@@ -116,8 +116,11 @@ export async function buildAndValidateSignature(options: TaskOriginVerifyOptions
 
   // Validate paths are within the allowed directory if specified
   if (allowedDir) {
-    assertWithinDir(taskFolderPath, allowedDir);
-    assertWithinDir(signatureFile, allowedDir);
+    const resolvedTaskFolderPath = await fs.realpath(taskFolderPath);
+    const resolvedSignatureFile = await fs.realpath(signatureFile);
+
+    assertWithinDir(resolvedTaskFolderPath, allowedDir);
+    assertWithinDir(resolvedSignatureFile, allowedDir);
   }
 
   // Extract the bundle containing both the signature and certificate chain
@@ -254,8 +257,11 @@ export async function verifyTaskOrigin(options: TaskOriginVerifyOptions): Promis
 
   // Validate paths are within the allowed directory if specified
   if (allowedDir) {
-    assertWithinDir(taskFolderPath, allowedDir);
-    assertWithinDir(signatureFile, allowedDir);
+    const resolvedTaskFolderPath = await fs.realpath(taskFolderPath);
+    const resolvedSignatureFile = await fs.realpath(signatureFile);
+
+    assertWithinDir(resolvedTaskFolderPath, allowedDir);
+    assertWithinDir(resolvedSignatureFile, allowedDir);
   }
 
   // Make sure that the task folder path and signature file exist


### PR DESCRIPTION
## Summary

Resolve filesystem paths with `fs.realpath()` before validating them with `assertWithinDir()` during task origin verification.

## Thesis 

Other filesystem operations in this module, such as `createDeterministicTarball()` and `getAllFilesRecursively()`, already resolve symlinks before validating paths. This change makes the verification flow consistent by validating canonical filesystem paths.

## Changes

- Resolve `taskFolderPath` before validation.
- Resolve `signatureFile` before validation.
- Apply the same behavior in:
  - `buildAndValidateSignature()`
  - `verifyTaskOrigin()`

## Diff

```diff
- assertWithinDir(taskFolderPath, allowedDir);
- assertWithinDir(signatureFile, allowedDir);

+ const resolvedTaskFolderPath = await fs.realpath(taskFolderPath);
+ const resolvedSignatureFile = await fs.realpath(signatureFile);
+
+ assertWithinDir(resolvedTaskFolderPath, allowedDir);
+ assertWithinDir(resolvedSignatureFile, allowedDir);
```