### PR TITLE
fix: always install selected task dependencies

### DIFF
--- a/src/app/api/install-deps/route.ts
+++ b/src/app/api/install-deps/route.ts
@@ -21,7 +21,7 @@ const pathExists = async (targetPath: string) => {
 export async function POST(req: NextRequest) {
   try {
     const json = await req.json();
-    const { network, upgradeId, forceInstall } = json;
+    const { network, upgradeId } = json;
 
     if (!network || !upgradeId) {
       return NextResponse.json(
@@ -31,7 +31,6 @@ export async function POST(req: NextRequest) {
     }
 
     const actualNetwork = network.toLowerCase();
-    const shouldForceInstall = Boolean(forceInstall);
 
     const safePathPattern = /^[a-zA-Z0-9_-]+$/;
     if (!safePathPattern.test(actualNetwork) || !safePathPattern.test(upgradeId)) {
@@ -64,24 +63,6 @@ export async function POST(req: NextRequest) {
       return NextResponse.json(
         { error: `Task folder not found: ${path.relative(contractDeploymentsPath, taskPath)}` },
         { status: 404 }
-      );
-    }
-
-    const libExistsBeforeInstall = await pathExists(libPath);
-
-    if (!shouldForceInstall && libExistsBeforeInstall) {
-      console.log(`Deps already installed for ${actualNetwork}/${upgradeId}; skipping.`);
-      return NextResponse.json(
-        {
-          success: true,
-          message: `Dependencies already installed for ${actualNetwork}/${upgradeId}`,
-          libExists: true,
-          installed: false,
-          depsInstalled: false,
-          stdout: '',
-          stderr: '',
-        },
-        { status: 200 }
       );
     }
 


### PR DESCRIPTION
## What changed?

Always runs `make deps` from the task selected in the signer UI instead of reusing an existing shared `active/evm/lib` directory.

The selected task Makefile already runs the shared root `deps` target, which removes `active/evm/lib` before installing that task's `BASE_CONTRACTS_COMMIT`. This also handles switching between tasks in one signer UI session, so contract-deployments no longer needs to purge dependencies in `make sign-task`.

## Checks

```bash
npx tsc --noEmit
npm run lint -- --no-cache
npm run build
```
