### PR TITLE
## fix: match expected/actual state changes, overrides, and balance changes by identity, not array position

### DIFF
--- a/src/lib/__tests__/validation-results-utils.test.ts
+++ b/src/lib/__tests__/validation-results-utils.test.ts
@@ -1,0 +1,107 @@
+import { buildValidationItems, hasBlockingErrors } from '../validation-results-utils';
+import type { ValidationData } from '../types/validation-data';
+
+describe('buildValidationItems change/override/balance matching', () => {
+  it('does not report a false mismatch when config order differs from actual (sorted) order', () => {
+    const ownerChange = {
+      key: '0x0000000000000000000000000000000000000000000000000000000000000001',
+      before: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      after: '0x000000000000000000000000000000000000000000000000000000000000dead',
+      description: 'owner slot',
+      allowDifference: false,
+    };
+
+    const pausedChange = {
+      key: '0x0000000000000000000000000000000000000000000000000000000000000002',
+      before: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      after: '0x0000000000000000000000000000000000000000000000000000000000000001',
+      description: 'paused flag',
+      allowDifference: false,
+    };
+
+    // Human-authored config: paused flag listed first (narratively relevant),
+    // owner slot second. getExpectedData() in validation-service.ts returns
+    // parsedConfig.stateChanges completely unsorted, exactly like this.
+    const expectedStateChanges = [
+      {
+        name: 'MyContract',
+        address: '0x0000000000000000000000000000000000000010' as `0x${string}`,
+        changes: [pausedChange, ownerChange],
+      },
+    ];
+
+    // state-diff.ts's ValidatorStateDiff always sorts a contract's changes by
+    // key ascending (see the `.sort((a, b) => a.key.localeCompare(b.key))`
+    // call it makes before returning results) -- so "actual" naturally comes
+    // back owner-slot-first here, same two changes, same values.
+    const actualStateChanges = [
+      {
+        name: 'MyContract',
+        address: '0x0000000000000000000000000000000000000010' as `0x${string}`,
+        changes: [ownerChange, pausedChange],
+      },
+    ];
+
+    const validationResult: ValidationData = {
+      expected: { stateOverrides: [], stateChanges: expectedStateChanges, balanceChanges: [] },
+      actual: { stateOverrides: [], stateChanges: actualStateChanges, balanceChanges: [] },
+    };
+
+    const items = buildValidationItems(validationResult);
+
+    // Each expected entry is paired with the actual entry that has the same
+    // key, regardless of position in either array.
+    const paused = items.changes.find(c => c.expected.description === 'paused flag');
+    const owner = items.changes.find(c => c.expected.description === 'owner slot');
+    expect(paused?.actual?.key).toBe(pausedChange.key);
+    expect(owner?.actual?.key).toBe(ownerChange.key);
+
+    // A task where the real on-chain state changes exactly match what the
+    // config expects (same keys, same before/after values) must not be
+    // flagged as a blocking validation failure just because of array order.
+    expect(hasBlockingErrors(items)).toBe(false);
+  });
+
+  it('still reports a genuine mismatch when the actual value truly differs', () => {
+    const expectedStateChanges = [
+      {
+        name: 'MyContract',
+        address: '0x0000000000000000000000000000000000000010' as `0x${string}`,
+        changes: [
+          {
+            key: '0x0000000000000000000000000000000000000000000000000000000000000001',
+            before: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            after: '0x000000000000000000000000000000000000000000000000000000000000dead',
+            description: 'owner slot',
+            allowDifference: false,
+          },
+        ],
+      },
+    ];
+
+    const actualStateChanges = [
+      {
+        name: 'MyContract',
+        address: '0x0000000000000000000000000000000000000010' as `0x${string}`,
+        changes: [
+          {
+            key: '0x0000000000000000000000000000000000000000000000000000000000000001',
+            before: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            // actually set to a different address than expected -- a real mismatch
+            after: '0x000000000000000000000000000000000000000000000000000000beef0000',
+            description: 'owner slot',
+            allowDifference: false,
+          },
+        ],
+      },
+    ];
+
+    const validationResult: ValidationData = {
+      expected: { stateOverrides: [], stateChanges: expectedStateChanges, balanceChanges: [] },
+      actual: { stateOverrides: [], stateChanges: actualStateChanges, balanceChanges: [] },
+    };
+
+    const items = buildValidationItems(validationResult);
+    expect(hasBlockingErrors(items)).toBe(true);
+  });
+});

--- a/src/lib/validation-results-utils.ts
+++ b/src/lib/validation-results-utils.ts
@@ -255,6 +255,19 @@ const buildSigningComparisons = (
   ];
 };
 
+// Both buildOverrideComparisons and buildChangeComparisons pair an expected
+// entry for a contract with the matching actual entry for that same
+// contract. The state-diff pipeline (state-diff.ts) always returns a
+// contract's overrides/changes sorted by key ascending, but the expected
+// side comes straight from the task's config JSON with no such ordering
+// applied (see getExpectedData in validation-service.ts) -- a config author
+// is free to list changes in whatever order makes sense narratively. Two
+// arrays with the same *contents* in a different *order* are still the same
+// data, so contracts (and, within a contract, individual keys) must be
+// matched by identity, not by raw array position.
+const findByAddress = <T extends { address: string }>(list: T[], address: string): T | undefined =>
+  list.find(entry => entry.address.toLowerCase() === address.toLowerCase());
+
 const buildOverrideComparisons = (
   validationResult: ValidationData | null
 ): OverrideComparison[] => {
@@ -263,14 +276,19 @@ const buildOverrideComparisons = (
   const expectedOverrides = validationResult.expected.stateOverrides ?? [];
   const actualOverrides = validationResult.actual.stateOverrides ?? [];
 
-  return expectedOverrides.flatMap((stateOverride, soIndex) =>
-    stateOverride.overrides.map((override, oIndex) => ({
+  return expectedOverrides.flatMap(stateOverride => {
+    const actualStateOverride = findByAddress(actualOverrides, stateOverride.address);
+    const actualByKey = new Map(
+      (actualStateOverride?.overrides ?? []).map(override => [override.key, override])
+    );
+
+    return stateOverride.overrides.map(override => ({
       contractName: stateOverride.name,
       contractAddress: stateOverride.address,
       expected: override,
-      actual: actualOverrides[soIndex]?.overrides?.[oIndex],
-    }))
-  );
+      actual: actualByKey.get(override.key),
+    }));
+  });
 };
 
 const buildChangeComparisons = (
@@ -281,14 +299,19 @@ const buildChangeComparisons = (
   const expectedChanges = validationResult.expected.stateChanges ?? [];
   const actualChanges = validationResult.actual.stateChanges ?? [];
 
-  return expectedChanges.flatMap((stateChange, scIndex) =>
-    stateChange.changes.map((change, cIndex) => ({
+  return expectedChanges.flatMap(stateChange => {
+    const actualStateChange = findByAddress(actualChanges, stateChange.address);
+    const actualByKey = new Map(
+      (actualStateChange?.changes ?? []).map(change => [change.key, change])
+    );
+
+    return stateChange.changes.map(change => ({
       contractName: stateChange.name,
       contractAddress: stateChange.address,
       expected: change,
-      actual: actualChanges[scIndex]?.changes?.[cIndex],
-    }))
-  );
+      actual: actualByKey.get(change.key),
+    }));
+  });
 };
 
 const buildBalanceComparisons = (
@@ -299,12 +322,20 @@ const buildBalanceComparisons = (
   const expectedBalances = validationResult.expected.balanceChanges ?? [];
   const actualBalances = validationResult.actual.balanceChanges ?? [];
 
-  return expectedBalances.map((balanceChange, bcIndex) => ({
-    contractName: balanceChange.name,
-    contractAddress: balanceChange.address,
-    expected: balanceChange,
-    actual: actualBalances[bcIndex],
-  }));
+  return expectedBalances.map(balanceChange => {
+    const actual = actualBalances.find(
+      candidate =>
+        candidate.address.toLowerCase() === balanceChange.address.toLowerCase() &&
+        candidate.field === balanceChange.field
+    );
+
+    return {
+      contractName: balanceChange.name,
+      contractAddress: balanceChange.address,
+      expected: balanceChange,
+      actual,
+    };
+  });
 };
 
 export const buildValidationItems = (


### PR DESCRIPTION
### The bug

`buildOverrideComparisons`, `buildChangeComparisons`, and
`buildBalanceComparisons` in `src/lib/validation-results-utils.ts` pair each
expected entry with an actual entry purely by array index:

```ts
actual: actualChanges[scIndex]?.changes?.[cIndex]
```

The two sides don't share an ordering guarantee, though:

- **actual** comes from the state-diff simulation pipeline
  (`state-diff.ts`), which always sorts a contract's overrides/changes by
  key ascending before returning them (`.sort((a, b) =>
  a.key.localeCompare(b.key))`).
- **expected** comes straight from the task's config JSON
  (`getExpectedData` in `validation-service.ts` returns
  `parsedConfig.stateChanges` as-is, unsorted).

A config author has no reason to write state changes in raw-hex-key
ascending order — listing them in whatever order is narratively useful
(e.g. "the important flag first, then the owner slot") is completely
reasonable. When that order doesn't happen to match the pipeline's sorted
output, index-based pairing cross-wires unrelated entries. `matchesChange`
/ `matchesOverride` (which check `expected.key === actual.key`) then
correctly detect the key mismatch on the wrongly-paired entries — and
`hasBlockingErrors` reports a blocking validation failure for a task whose
actual on-chain effect is byte-for-byte identical to what the config
expects.

To be clear about the direction of the bug: this is a false positive (a
correct task gets flagged as mismatched), not a false negative — it
doesn't cause an incorrect task to be accepted. But it directly undermines
the tool's job of telling a signer whether a task is safe to sign, and a
signer who sees a reported mismatch has no way to tell, from the tool's
output alone, whether it's this ordering artifact or a real problem.

### Reproduction

Added as the first case in the new test file: two storage-slot changes on
one contract, identical values on both the expected and actual side, only
the order differs (config lists them as [paused, owner]; the simulation
naturally returns them key-sorted as [owner, paused]). Before this fix,
`hasBlockingErrors(items)` returns `true` for this input despite the task
being entirely correct.

### The fix

Match each expected entry to its actual counterpart by identity instead of
position:

- Overrides/changes: look up the actual contract entry by `address`
  (case-insensitively), then look up the specific override/change by `key`
  within that contract via a `Map`.
- Balance changes: look up by `address` + `field` together, since a
  contract can have more than one tracked balance-type field.

`matchesOverride` / `matchesChange` / `matchesBalance` and
`hasBlockingErrors` are untouched — this only changes which actual entry
gets handed to them for comparison.

### Testing

New file `src/lib/__tests__/validation-results-utils.test.ts`:

- Reproduces the bug directly against `buildValidationItems` +
  `hasBlockingErrors` (fails before the fix, passes after): reordered but
  semantically-identical expected/actual data no longer produces a
  blocking mismatch, and each entry is verified to be paired with its
  correct counterpart by key.
- A second case with a genuinely different `after` value confirms the fix
  doesn't mask real mismatches — `hasBlockingErrors` still correctly
  returns `true`.

Full verification:
- `npx tsc --noEmit` — clean
- `npx eslint src/lib/validation-results-utils.ts src/lib/__tests__/validation-results-utils.test.ts` — clean
- `npx prettier --check` — clean
- `npx jest --runInBand` (full suite) — **108/108 passing**, no regressions

### Scope

Two files: the fix itself and its test. No changes to the matching
functions' semantics (`matchesChange` etc.), the blocking-decision logic,
or any UI code.