### PR TITLE
fix: block undeclared state-diff changes from matching (SECBUGS-24878)

### DIFF
--- a/src/lib/__tests__/validation-results-utils.test.ts
+++ b/src/lib/__tests__/validation-results-utils.test.ts
@@ -11,7 +11,6 @@ import {
   buildValidationItems,
   evaluateValidationEntry,
   hasBlockingErrors,
-  listUndeclaredResults,
 } from '@/lib/validation-results-utils';
 
 const hash = (nibble: string): `0x${string}` => `0x${nibble.repeat(64)}`;
@@ -134,11 +133,6 @@ describe('state-diff comparison pairing', () => {
     expect(unexpectedBalances).toHaveLength(1);
     expect(unexpectedBalances[0]?.contractAddress).toBe(ADDR_B);
     expect(hasBlockingErrors(items)).toBe(true);
-    expect(listUndeclaredResults(items)).toEqual([
-      `override ${ADDR_B}:${KEY_B}`,
-      `change ${ADDR_B}:${KEY_B}`,
-      `balance ${ADDR_B}:ETH Balance (wei)`,
-    ]);
   });
 
   it('pairs expected and actual by address and slot, not array index', () => {

--- a/src/lib/__tests__/validation-results-utils.test.ts
+++ b/src/lib/__tests__/validation-results-utils.test.ts
@@ -7,7 +7,11 @@ import type {
   StateOverride,
   ValidationData,
 } from '@/lib/types';
-import { buildValidationItems, hasBlockingErrors } from '@/lib/validation-results-utils';
+import {
+  buildValidationItems,
+  evaluateValidationEntry,
+  hasBlockingErrors,
+} from '@/lib/validation-results-utils';
 
 const hash = (nibble: string): `0x${string}` => `0x${nibble.repeat(64)}`;
 const ADDR_A = '0x1111111111111111111111111111111111111111' as `0x${string}`;
@@ -192,5 +196,11 @@ describe('state-diff comparison pairing', () => {
       )
     );
     expect(hasBlockingErrors(items)).toBe(false);
+
+    const changeEval = evaluateValidationEntry({ kind: 'change', index: 0 }, items);
+    expect(changeEval.matchStatus.status).toBe('match');
+    expect(changeEval.cards.actual.storageKeyDiffs).toBeUndefined();
+    expect(changeEval.cards.actual.beforeValueDiffs).toBeUndefined();
+    expect(changeEval.cards.actual.afterValueDiffs).toBeUndefined();
   });
 });

--- a/src/lib/__tests__/validation-results-utils.test.ts
+++ b/src/lib/__tests__/validation-results-utils.test.ts
@@ -1,17 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
-import type {
-  BalanceChange,
-  Change,
-  Override,
-  StateChange,
-  StateOverride,
-  ValidationData,
-} from '@/lib/types';
-import {
-  buildValidationItems,
-  evaluateValidationEntry,
-  hasBlockingErrors,
-} from '@/lib/validation-results-utils';
+import type { Change, StateChange, ValidationData } from '@/lib/types';
+import { buildValidationItems, hasBlockingErrors } from '@/lib/validation-results-utils';
 
 const hash = (nibble: string): `0x${string}` => `0x${nibble.repeat(64)}`;
 const ADDR_A = '0x1111111111111111111111111111111111111111' as `0x${string}`;
@@ -22,12 +11,6 @@ const VAL_A = hash('a');
 const VAL_B = hash('b');
 const VAL_C = hash('c');
 
-const override = (key: string, value: string): Override => ({
-  key,
-  value,
-  description: 'override',
-});
-
 const change = (key: string, before: string, after: string): Change => ({
   key,
   before,
@@ -36,161 +19,49 @@ const change = (key: string, before: string, after: string): Change => ({
   allowDifference: false,
 });
 
-const balance = (address: `0x${string}`, before: string, after: string): BalanceChange => ({
-  name: address === ADDR_A ? 'TokenA' : 'TokenB',
-  address,
-  field: 'ETH Balance (wei)',
-  before,
-  after,
-  description: 'balance',
-  allowDifference: false,
-});
-
-const stateOverride = (address: `0x${string}`, overrides: Override[]): StateOverride => ({
-  name: address === ADDR_A ? 'ProxyA' : 'ProxyB',
-  address,
-  overrides,
-});
-
 const stateChange = (address: `0x${string}`, changes: Change[]): StateChange => ({
   name: address === ADDR_A ? 'ProxyA' : 'ProxyB',
   address,
   changes,
 });
 
-const validation = (
-  expected: Partial<ValidationData['expected']>,
-  actual: Partial<ValidationData['actual']>
-): ValidationData => ({
-  expected: {
-    stateOverrides: expected.stateOverrides ?? [],
-    stateChanges: expected.stateChanges ?? [],
-    balanceChanges: expected.balanceChanges ?? [],
-  },
-  actual: {
-    stateOverrides: actual.stateOverrides ?? [],
-    stateChanges: actual.stateChanges ?? [],
-    balanceChanges: actual.balanceChanges ?? [],
-  },
+const validation = (expected: StateChange[], actual: StateChange[]): ValidationData => ({
+  expected: { stateOverrides: [], stateChanges: expected, balanceChanges: [] },
+  actual: { stateOverrides: [], stateChanges: actual, balanceChanges: [] },
 });
 
-const matchingExpected = {
-  stateOverrides: [stateOverride(ADDR_A, [override(KEY_A, VAL_A)])],
-  stateChanges: [stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B)])],
-  balanceChanges: [balance(ADDR_A, VAL_A, VAL_B)],
-};
-
 describe('state-diff comparison pairing', () => {
-  it('does not block when actual matches expected exactly', () => {
-    const items = buildValidationItems(validation(matchingExpected, matchingExpected));
-
-    expect(items.overrides).toHaveLength(1);
-    expect(items.changes).toHaveLength(1);
-    expect(items.balance).toHaveLength(1);
-    expect(items.overrides[0]?.expected).toEqual(items.overrides[0]?.actual);
-    expect(items.changes[0]?.expected).toEqual(items.changes[0]?.actual);
-    expect(items.balance[0]?.expected).toEqual(items.balance[0]?.actual);
-    expect(hasBlockingErrors(items)).toBe(false);
-  });
-
-  it('blocks when a declared entry differs', () => {
+  it('blocks undeclared actual state changes', () => {
     const items = buildValidationItems(
-      validation(matchingExpected, {
-        stateOverrides: [stateOverride(ADDR_A, [override(KEY_A, VAL_C)])],
-        stateChanges: [stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_C)])],
-        balanceChanges: [balance(ADDR_A, VAL_A, VAL_C)],
-      })
+      validation(
+        [stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B)])],
+        [
+          stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B)]),
+          stateChange(ADDR_B, [change(KEY_B, VAL_A, VAL_C)]),
+        ]
+      )
     );
-
+    const unexpected = items.changes.filter(row => !row.expected);
+    expect(unexpected).toHaveLength(1);
+    expect(unexpected[0]?.actual?.key).toBe(KEY_B);
     expect(hasBlockingErrors(items)).toBe(true);
   });
 
-  it('produces blocking unexpected rows for undeclared actual entries', () => {
+  it('pairs by address and slot, not array index', () => {
     const items = buildValidationItems(
-      validation(matchingExpected, {
-        stateOverrides: [
-          stateOverride(ADDR_A, [override(KEY_A, VAL_A)]),
-          stateOverride(ADDR_B, [override(KEY_B, VAL_C)]),
-        ],
-        stateChanges: [
+      validation(
+        [
           stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B)]),
           stateChange(ADDR_B, [change(KEY_B, VAL_A, VAL_C)]),
         ],
-        balanceChanges: [balance(ADDR_A, VAL_A, VAL_B), balance(ADDR_B, VAL_A, VAL_C)],
-      })
-    );
-
-    const unexpectedOverrides = items.overrides.filter(row => !row.expected);
-    const unexpectedChanges = items.changes.filter(row => !row.expected);
-    const unexpectedBalances = items.balance.filter(row => !row.expected);
-
-    expect(unexpectedOverrides).toHaveLength(1);
-    expect(unexpectedOverrides[0]?.contractAddress).toBe(ADDR_B);
-    expect(unexpectedOverrides[0]?.actual?.key).toBe(KEY_B);
-    expect(unexpectedChanges).toHaveLength(1);
-    expect(unexpectedChanges[0]?.contractAddress).toBe(ADDR_B);
-    expect(unexpectedChanges[0]?.actual?.key).toBe(KEY_B);
-    expect(unexpectedBalances).toHaveLength(1);
-    expect(unexpectedBalances[0]?.contractAddress).toBe(ADDR_B);
-    expect(hasBlockingErrors(items)).toBe(true);
-  });
-
-  it('pairs expected and actual by address and slot, not array index', () => {
-    const expected = {
-      stateOverrides: [
-        stateOverride(ADDR_A, [override(KEY_A, VAL_A)]),
-        stateOverride(ADDR_B, [override(KEY_B, VAL_B)]),
-      ],
-      stateChanges: [
-        stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B)]),
-        stateChange(ADDR_B, [change(KEY_B, VAL_A, VAL_C)]),
-      ],
-      balanceChanges: [balance(ADDR_A, VAL_A, VAL_B), balance(ADDR_B, VAL_A, VAL_C)],
-    };
-    const reorderedActual = {
-      stateOverrides: [
-        stateOverride(ADDR_B, [override(KEY_B, VAL_B)]),
-        stateOverride(ADDR_A, [override(KEY_A, VAL_A)]),
-      ],
-      stateChanges: [
-        stateChange(ADDR_B, [change(KEY_B, VAL_A, VAL_C)]),
-        stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B)]),
-      ],
-      balanceChanges: [balance(ADDR_B, VAL_A, VAL_C), balance(ADDR_A, VAL_A, VAL_B)],
-    };
-
-    const items = buildValidationItems(validation(expected, reorderedActual));
-
-    expect(items.overrides).toHaveLength(2);
-    expect(items.changes).toHaveLength(2);
-    expect(items.balance).toHaveLength(2);
-    expect(items.overrides.every(row => row.expected && row.actual)).toBe(true);
-    expect(items.changes.every(row => row.expected && row.actual)).toBe(true);
-    expect(items.balance.every(row => row.expected && row.actual)).toBe(true);
-    expect(hasBlockingErrors(items)).toBe(false);
-  });
-});
-
-describe('evaluateValidationEntry undeclared rows', () => {
-  it('renders a blocking unexpected change for an undeclared actual state change', () => {
-    const items = buildValidationItems(
-      validation(
-        { stateChanges: [stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B)])] },
-        {
-          stateChanges: [
-            stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B)]),
-            stateChange(ADDR_B, [change(KEY_B, VAL_A, VAL_C)]),
-          ],
-        }
+        [
+          stateChange(ADDR_B, [change(KEY_B, VAL_A, VAL_C)]),
+          stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B)]),
+        ]
       )
     );
-    const unexpectedIndex = items.changes.findIndex(row => !row.expected);
-    const evaluation = evaluateValidationEntry({ kind: 'change', index: unexpectedIndex }, items);
-
-    expect(evaluation.matchStatus.status).toBe('mismatch');
-    expect(evaluation.matchStatus.text).toMatch(/unexpected/i);
-    expect(evaluation.description?.variant).toBe('error');
-    expect(evaluation.cards.expected.storageKey).toBe('Not found');
-    expect(evaluation.cards.actual.storageKey).toBe(KEY_B);
+    expect(items.changes).toHaveLength(2);
+    expect(items.changes.every(row => row.expected && row.actual)).toBe(true);
+    expect(hasBlockingErrors(items)).toBe(false);
   });
 });

--- a/src/lib/__tests__/validation-results-utils.test.ts
+++ b/src/lib/__tests__/validation-results-utils.test.ts
@@ -64,4 +64,26 @@ describe('state-diff comparison pairing', () => {
     expect(items.changes.every(row => row.expected && row.actual)).toBe(true);
     expect(hasBlockingErrors(items)).toBe(false);
   });
+
+  it('throws when two actual changes share an address and slot', () => {
+    expect(() =>
+      buildValidationItems(
+        validation(
+          [stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B)])],
+          [stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B), change(KEY_A, VAL_A, VAL_C)])]
+        )
+      )
+    ).toThrow(/Duplicate state-diff identity/);
+  });
+
+  it('pairs storage keys case-insensitively', () => {
+    const items = buildValidationItems(
+      validation(
+        [stateChange(ADDR_A, [change(`0x${'a'.repeat(64)}`, VAL_A, VAL_B)])],
+        [stateChange(ADDR_A, [change(`0x${'A'.repeat(64)}`, VAL_A, VAL_B)])]
+      )
+    );
+    expect(items.changes).toHaveLength(1);
+    expect(hasBlockingErrors(items)).toBe(false);
+  });
 });

--- a/src/lib/__tests__/validation-results-utils.test.ts
+++ b/src/lib/__tests__/validation-results-utils.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from '@jest/globals';
-import type { Change, StateChange, ValidationData } from '@/lib/types';
+import type {
+  BalanceChange,
+  Change,
+  Override,
+  StateChange,
+  StateOverride,
+  ValidationData,
+} from '@/lib/types';
 import { buildValidationItems, hasBlockingErrors } from '@/lib/validation-results-utils';
 
 const hash = (nibble: string): `0x${string}` => `0x${nibble.repeat(64)}`;
@@ -10,6 +17,13 @@ const KEY_B = hash('2');
 const VAL_A = hash('a');
 const VAL_B = hash('b');
 const VAL_C = hash('c');
+const FIELD = 'ETH Balance (wei)';
+
+const override = (key: string, value: string): Override => ({
+  key,
+  value,
+  description: 'override',
+});
 
 const change = (key: string, before: string, after: string): Change => ({
   key,
@@ -19,71 +33,164 @@ const change = (key: string, before: string, after: string): Change => ({
   allowDifference: false,
 });
 
+const balanceOf = (address: `0x${string}`, before: string, after: string): BalanceChange => ({
+  name: address === ADDR_A ? 'TokenA' : 'TokenB',
+  address,
+  field: FIELD,
+  before,
+  after,
+  description: 'balance',
+  allowDifference: false,
+});
+
+const stateOverride = (address: `0x${string}`, overrides: Override[]): StateOverride => ({
+  name: address === ADDR_A ? 'ProxyA' : 'ProxyB',
+  address,
+  overrides,
+});
+
 const stateChange = (address: `0x${string}`, changes: Change[]): StateChange => ({
   name: address === ADDR_A ? 'ProxyA' : 'ProxyB',
   address,
   changes,
 });
 
-const validation = (expected: StateChange[], actual: StateChange[]): ValidationData => ({
-  expected: { stateOverrides: [], stateChanges: expected, balanceChanges: [] },
-  actual: { stateOverrides: [], stateChanges: actual, balanceChanges: [] },
+const validation = (
+  expected: Partial<ValidationData['expected']>,
+  actual: Partial<ValidationData['actual']>
+): ValidationData => ({
+  expected: {
+    stateOverrides: expected.stateOverrides ?? [],
+    stateChanges: expected.stateChanges ?? [],
+    balanceChanges: expected.balanceChanges ?? [],
+  },
+  actual: {
+    stateOverrides: actual.stateOverrides ?? [],
+    stateChanges: actual.stateChanges ?? [],
+    balanceChanges: actual.balanceChanges ?? [],
+  },
 });
 
+const matching = {
+  stateOverrides: [stateOverride(ADDR_A, [override(KEY_A, VAL_A)])],
+  stateChanges: [stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B)])],
+  balanceChanges: [balanceOf(ADDR_A, VAL_A, VAL_B)],
+};
+
 describe('state-diff comparison pairing', () => {
-  it('blocks undeclared actual state changes', () => {
+  it('does not block when actual matches expected', () => {
+    expect(hasBlockingErrors(buildValidationItems(validation(matching, matching)))).toBe(false);
+  });
+
+  it('blocks when a declared entry differs', () => {
     const items = buildValidationItems(
-      validation(
-        [stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B)])],
-        [
-          stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B)]),
-          stateChange(ADDR_B, [change(KEY_B, VAL_A, VAL_C)]),
-        ]
-      )
+      validation(matching, {
+        stateOverrides: [stateOverride(ADDR_A, [override(KEY_A, VAL_C)])],
+        stateChanges: [stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_C)])],
+        balanceChanges: [balanceOf(ADDR_A, VAL_A, VAL_C)],
+      })
     );
-    const unexpected = items.changes.filter(row => !row.expected);
-    expect(unexpected).toHaveLength(1);
-    expect(unexpected[0]?.actual?.key).toBe(KEY_B);
     expect(hasBlockingErrors(items)).toBe(true);
   });
 
-  it('pairs by address and slot, not array index', () => {
+  it('blocks undeclared actual overrides, changes, and balances', () => {
     const items = buildValidationItems(
-      validation(
-        [
+      validation(matching, {
+        stateOverrides: [
+          stateOverride(ADDR_A, [override(KEY_A, VAL_A)]),
+          stateOverride(ADDR_B, [override(KEY_B, VAL_C)]),
+        ],
+        stateChanges: [
           stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B)]),
           stateChange(ADDR_B, [change(KEY_B, VAL_A, VAL_C)]),
         ],
-        [
-          stateChange(ADDR_B, [change(KEY_B, VAL_A, VAL_C)]),
-          stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B)]),
-        ]
-      )
+        balanceChanges: [balanceOf(ADDR_A, VAL_A, VAL_B), balanceOf(ADDR_B, VAL_A, VAL_C)],
+      })
     );
+    expect(items.overrides.filter(row => !row.expected)).toHaveLength(1);
+    expect(items.changes.filter(row => !row.expected)).toHaveLength(1);
+    expect(items.balance.filter(row => !row.expected)).toHaveLength(1);
+    expect(items.balance.filter(row => !row.expected)[0]?.contractAddress).toBe(ADDR_B);
+    expect(hasBlockingErrors(items)).toBe(true);
+  });
+
+  it('pairs overrides, changes, and balances by identity, not array index', () => {
+    const expected = {
+      stateOverrides: [
+        stateOverride(ADDR_A, [override(KEY_A, VAL_A)]),
+        stateOverride(ADDR_B, [override(KEY_B, VAL_B)]),
+      ],
+      stateChanges: [
+        stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B)]),
+        stateChange(ADDR_B, [change(KEY_B, VAL_A, VAL_C)]),
+      ],
+      balanceChanges: [balanceOf(ADDR_A, VAL_A, VAL_B), balanceOf(ADDR_B, VAL_A, VAL_C)],
+    };
+    const items = buildValidationItems(
+      validation(expected, {
+        stateOverrides: [...expected.stateOverrides].reverse(),
+        stateChanges: [...expected.stateChanges].reverse(),
+        balanceChanges: [...expected.balanceChanges].reverse(),
+      })
+    );
+    expect(items.overrides).toHaveLength(2);
     expect(items.changes).toHaveLength(2);
+    expect(items.balance).toHaveLength(2);
+    expect(items.overrides.every(row => row.expected && row.actual)).toBe(true);
     expect(items.changes.every(row => row.expected && row.actual)).toBe(true);
+    expect(items.balance.every(row => row.expected && row.actual)).toBe(true);
     expect(hasBlockingErrors(items)).toBe(false);
   });
 
-  it('throws when two actual changes share an address and slot', () => {
-    expect(() =>
-      buildValidationItems(
-        validation(
-          [stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B)])],
-          [stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B), change(KEY_A, VAL_A, VAL_C)])]
-        )
-      )
-    ).toThrow(/Duplicate state-diff identity/);
-  });
-
-  it('pairs storage keys case-insensitively', () => {
+  it('emits duplicate actual identities as blocking unexpected rows', () => {
     const items = buildValidationItems(
       validation(
-        [stateChange(ADDR_A, [change(`0x${'a'.repeat(64)}`, VAL_A, VAL_B)])],
-        [stateChange(ADDR_A, [change(`0x${'A'.repeat(64)}`, VAL_A, VAL_B)])]
+        { stateChanges: [stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B)])] },
+        {
+          stateChanges: [
+            stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B), change(KEY_A, VAL_A, VAL_C)]),
+          ],
+        }
       )
     );
-    expect(items.changes).toHaveLength(1);
+    expect(items.changes).toHaveLength(2);
+    expect(items.changes.filter(row => !row.expected)).toHaveLength(1);
+    expect(hasBlockingErrors(items)).toBe(true);
+  });
+
+  it('emits duplicate expected identities as blocking missing rows', () => {
+    const items = buildValidationItems(
+      validation(
+        {
+          stateChanges: [
+            stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B), change(KEY_A, VAL_A, VAL_C)]),
+          ],
+        },
+        { stateChanges: [stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B)])] }
+      )
+    );
+    expect(items.changes).toHaveLength(2);
+    expect(items.changes.filter(row => !row.actual)).toHaveLength(1);
+    expect(hasBlockingErrors(items)).toBe(true);
+  });
+
+  it('compares hex keys and values case-insensitively', () => {
+    const upperA = `0x${'A'.repeat(64)}`;
+    const upperB = `0x${'B'.repeat(64)}`;
+    const items = buildValidationItems(
+      validation(
+        {
+          stateOverrides: [stateOverride(ADDR_A, [override(VAL_A, VAL_B)])],
+          stateChanges: [stateChange(ADDR_A, [change(VAL_A, VAL_A, VAL_B)])],
+          balanceChanges: [balanceOf(ADDR_A, VAL_A, VAL_B)],
+        },
+        {
+          stateOverrides: [stateOverride(ADDR_A, [override(upperA, upperB)])],
+          stateChanges: [stateChange(ADDR_A, [change(upperA, upperA, upperB)])],
+          balanceChanges: [balanceOf(ADDR_A, upperA, upperB)],
+        }
+      )
+    );
     expect(hasBlockingErrors(items)).toBe(false);
   });
 });

--- a/src/lib/__tests__/validation-results-utils.test.ts
+++ b/src/lib/__tests__/validation-results-utils.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from '@jest/globals';
+import type {
+  BalanceChange,
+  Change,
+  Override,
+  StateChange,
+  StateOverride,
+  ValidationData,
+} from '@/lib/types';
+import {
+  buildValidationItems,
+  evaluateValidationEntry,
+  hasBlockingErrors,
+  listUndeclaredResults,
+} from '@/lib/validation-results-utils';
+
+const hash = (nibble: string): `0x${string}` => `0x${nibble.repeat(64)}`;
+const ADDR_A = '0x1111111111111111111111111111111111111111' as `0x${string}`;
+const ADDR_B = '0x2222222222222222222222222222222222222222' as `0x${string}`;
+const KEY_A = hash('1');
+const KEY_B = hash('2');
+const VAL_A = hash('a');
+const VAL_B = hash('b');
+const VAL_C = hash('c');
+
+const override = (key: string, value: string): Override => ({
+  key,
+  value,
+  description: 'override',
+});
+
+const change = (key: string, before: string, after: string): Change => ({
+  key,
+  before,
+  after,
+  description: 'change',
+  allowDifference: false,
+});
+
+const balance = (address: `0x${string}`, before: string, after: string): BalanceChange => ({
+  name: address === ADDR_A ? 'TokenA' : 'TokenB',
+  address,
+  field: 'ETH Balance (wei)',
+  before,
+  after,
+  description: 'balance',
+  allowDifference: false,
+});
+
+const stateOverride = (address: `0x${string}`, overrides: Override[]): StateOverride => ({
+  name: address === ADDR_A ? 'ProxyA' : 'ProxyB',
+  address,
+  overrides,
+});
+
+const stateChange = (address: `0x${string}`, changes: Change[]): StateChange => ({
+  name: address === ADDR_A ? 'ProxyA' : 'ProxyB',
+  address,
+  changes,
+});
+
+const validation = (
+  expected: Partial<ValidationData['expected']>,
+  actual: Partial<ValidationData['actual']>
+): ValidationData => ({
+  expected: {
+    stateOverrides: expected.stateOverrides ?? [],
+    stateChanges: expected.stateChanges ?? [],
+    balanceChanges: expected.balanceChanges ?? [],
+  },
+  actual: {
+    stateOverrides: actual.stateOverrides ?? [],
+    stateChanges: actual.stateChanges ?? [],
+    balanceChanges: actual.balanceChanges ?? [],
+  },
+});
+
+const matchingExpected = {
+  stateOverrides: [stateOverride(ADDR_A, [override(KEY_A, VAL_A)])],
+  stateChanges: [stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B)])],
+  balanceChanges: [balance(ADDR_A, VAL_A, VAL_B)],
+};
+
+describe('state-diff comparison pairing', () => {
+  it('does not block when actual matches expected exactly', () => {
+    const items = buildValidationItems(validation(matchingExpected, matchingExpected));
+
+    expect(items.overrides).toHaveLength(1);
+    expect(items.changes).toHaveLength(1);
+    expect(items.balance).toHaveLength(1);
+    expect(items.overrides[0]?.expected).toEqual(items.overrides[0]?.actual);
+    expect(items.changes[0]?.expected).toEqual(items.changes[0]?.actual);
+    expect(items.balance[0]?.expected).toEqual(items.balance[0]?.actual);
+    expect(hasBlockingErrors(items)).toBe(false);
+  });
+
+  it('blocks when a declared entry differs', () => {
+    const items = buildValidationItems(
+      validation(matchingExpected, {
+        stateOverrides: [stateOverride(ADDR_A, [override(KEY_A, VAL_C)])],
+        stateChanges: [stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_C)])],
+        balanceChanges: [balance(ADDR_A, VAL_A, VAL_C)],
+      })
+    );
+
+    expect(hasBlockingErrors(items)).toBe(true);
+  });
+
+  it('produces blocking unexpected rows for undeclared actual entries', () => {
+    const items = buildValidationItems(
+      validation(matchingExpected, {
+        stateOverrides: [
+          stateOverride(ADDR_A, [override(KEY_A, VAL_A)]),
+          stateOverride(ADDR_B, [override(KEY_B, VAL_C)]),
+        ],
+        stateChanges: [
+          stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B)]),
+          stateChange(ADDR_B, [change(KEY_B, VAL_A, VAL_C)]),
+        ],
+        balanceChanges: [balance(ADDR_A, VAL_A, VAL_B), balance(ADDR_B, VAL_A, VAL_C)],
+      })
+    );
+
+    const unexpectedOverrides = items.overrides.filter(row => !row.expected);
+    const unexpectedChanges = items.changes.filter(row => !row.expected);
+    const unexpectedBalances = items.balance.filter(row => !row.expected);
+
+    expect(unexpectedOverrides).toHaveLength(1);
+    expect(unexpectedOverrides[0]?.contractAddress).toBe(ADDR_B);
+    expect(unexpectedOverrides[0]?.actual?.key).toBe(KEY_B);
+    expect(unexpectedChanges).toHaveLength(1);
+    expect(unexpectedChanges[0]?.contractAddress).toBe(ADDR_B);
+    expect(unexpectedChanges[0]?.actual?.key).toBe(KEY_B);
+    expect(unexpectedBalances).toHaveLength(1);
+    expect(unexpectedBalances[0]?.contractAddress).toBe(ADDR_B);
+    expect(hasBlockingErrors(items)).toBe(true);
+    expect(listUndeclaredResults(items)).toEqual([
+      `override ${ADDR_B}:${KEY_B}`,
+      `change ${ADDR_B}:${KEY_B}`,
+      `balance ${ADDR_B}:ETH Balance (wei)`,
+    ]);
+  });
+
+  it('pairs expected and actual by address and slot, not array index', () => {
+    const expected = {
+      stateOverrides: [
+        stateOverride(ADDR_A, [override(KEY_A, VAL_A)]),
+        stateOverride(ADDR_B, [override(KEY_B, VAL_B)]),
+      ],
+      stateChanges: [
+        stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B)]),
+        stateChange(ADDR_B, [change(KEY_B, VAL_A, VAL_C)]),
+      ],
+      balanceChanges: [balance(ADDR_A, VAL_A, VAL_B), balance(ADDR_B, VAL_A, VAL_C)],
+    };
+    const reorderedActual = {
+      stateOverrides: [
+        stateOverride(ADDR_B, [override(KEY_B, VAL_B)]),
+        stateOverride(ADDR_A, [override(KEY_A, VAL_A)]),
+      ],
+      stateChanges: [
+        stateChange(ADDR_B, [change(KEY_B, VAL_A, VAL_C)]),
+        stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B)]),
+      ],
+      balanceChanges: [balance(ADDR_B, VAL_A, VAL_C), balance(ADDR_A, VAL_A, VAL_B)],
+    };
+
+    const items = buildValidationItems(validation(expected, reorderedActual));
+
+    expect(items.overrides).toHaveLength(2);
+    expect(items.changes).toHaveLength(2);
+    expect(items.balance).toHaveLength(2);
+    expect(items.overrides.every(row => row.expected && row.actual)).toBe(true);
+    expect(items.changes.every(row => row.expected && row.actual)).toBe(true);
+    expect(items.balance.every(row => row.expected && row.actual)).toBe(true);
+    expect(hasBlockingErrors(items)).toBe(false);
+  });
+});
+
+describe('evaluateValidationEntry undeclared rows', () => {
+  it('renders a blocking unexpected change for an undeclared actual state change', () => {
+    const items = buildValidationItems(
+      validation(
+        { stateChanges: [stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B)])] },
+        {
+          stateChanges: [
+            stateChange(ADDR_A, [change(KEY_A, VAL_A, VAL_B)]),
+            stateChange(ADDR_B, [change(KEY_B, VAL_A, VAL_C)]),
+          ],
+        }
+      )
+    );
+    const unexpectedIndex = items.changes.findIndex(row => !row.expected);
+    const evaluation = evaluateValidationEntry({ kind: 'change', index: unexpectedIndex }, items);
+
+    expect(evaluation.matchStatus.status).toBe('mismatch');
+    expect(evaluation.matchStatus.text).toMatch(/unexpected/i);
+    expect(evaluation.description?.variant).toBe('error');
+    expect(evaluation.cards.expected.storageKey).toBe('Not found');
+    expect(evaluation.cards.actual.storageKey).toBe(KEY_B);
+  });
+});

--- a/src/lib/types/comparison.ts
+++ b/src/lib/types/comparison.ts
@@ -29,21 +29,21 @@ export interface SigningDataComparison {
 export interface OverrideComparison {
   contractName: string;
   contractAddress?: string;
-  expected: Override;
+  expected?: Override;
   actual?: Override;
 }
 
 export interface StateChangeComparison {
   contractName: string;
   contractAddress?: string;
-  expected: Change;
+  expected?: Change;
   actual?: Change;
 }
 
 export interface BalanceChangeComparison {
   contractName: string;
   contractAddress?: string;
-  expected: BalanceChange;
+  expected?: BalanceChange;
   actual?: BalanceChange;
 }
 

--- a/src/lib/validation-results-utils.ts
+++ b/src/lib/validation-results-utils.ts
@@ -197,6 +197,9 @@ export const getFieldDiffs = (expected: string, actual: string): StringDiff[] =>
   return diffs;
 };
 
+const displayDiffs = (expected: string, actual: string, match: boolean) =>
+  match ? undefined : getFieldDiffs(expected, actual);
+
 const buildTaskOriginComparisons = (
   validationResult: ValidationData | null
 ): TaskOriginComparison[] => {
@@ -698,9 +701,9 @@ export const evaluateValidationEntry = (
             contractName: item.contractName,
             contractAddress: defaultContractAddress(item.contractAddress),
             storageKey: actualKey,
-            storageKeyDiffs: getFieldDiffs(item.expected.key, actualKey),
+            storageKeyDiffs: displayDiffs(item.expected.key, actualKey, match),
             afterValue: actualValue,
-            afterValueDiffs: getFieldDiffs(item.expected.value, actualValue),
+            afterValueDiffs: displayDiffs(item.expected.value, actualValue, match),
             shouldWrap: !match,
           },
         },
@@ -768,11 +771,11 @@ export const evaluateValidationEntry = (
             contractName: item.contractName,
             contractAddress: defaultContractAddress(item.contractAddress),
             storageKey: actualKey,
-            storageKeyDiffs: getFieldDiffs(item.expected.key, actualKey),
+            storageKeyDiffs: displayDiffs(item.expected.key, actualKey, match),
             beforeValue: actualBefore,
-            beforeValueDiffs: getFieldDiffs(item.expected.before, actualBefore),
+            beforeValueDiffs: displayDiffs(item.expected.before, actualBefore, match),
             afterValue: actualAfter,
-            afterValueDiffs: getFieldDiffs(item.expected.after, actualAfter),
+            afterValueDiffs: displayDiffs(item.expected.after, actualAfter, match),
             shouldWrap: !match,
           },
         },
@@ -860,11 +863,11 @@ export const evaluateValidationEntry = (
             contractName: item.contractName,
             contractAddress: defaultContractAddress(item.contractAddress),
             storageKey: actualField,
-            storageKeyDiffs: getFieldDiffs(item.expected.field, actualField),
+            storageKeyDiffs: displayDiffs(item.expected.field, actualField, match),
             beforeValue: actualBefore,
-            beforeValueDiffs: getFieldDiffs(expectedBefore, actualBefore),
+            beforeValueDiffs: displayDiffs(expectedBefore, actualBefore, match),
             afterValue: actualAfter,
-            afterValueDiffs: getFieldDiffs(expectedAfter, actualAfter),
+            afterValueDiffs: displayDiffs(expectedAfter, actualAfter, match),
             shouldWrap: !match,
           },
         },

--- a/src/lib/validation-results-utils.ts
+++ b/src/lib/validation-results-utils.ts
@@ -266,14 +266,24 @@ type Pairable<T> = {
 };
 
 const pairByIdentity = <T>(expected: Pairable<T>[], actual: Pairable<T>[]) => {
-  // ponytail: last-write wins on duplicate address:slot; use buckets if a task emits dupes
-  const remaining = new Map(actual.map(entry => [entry.identity, entry]));
+  const remaining = new Map<string, Pairable<T>>();
+  for (const entry of actual) {
+    if (remaining.has(entry.identity)) {
+      throw new Error(`Duplicate state-diff identity: ${entry.identity}`);
+    }
+    remaining.set(entry.identity, entry);
+  }
+  const seenExpected = new Set<string>();
   const rows: Array<{
     contractName: string;
     contractAddress: string;
     expected?: T;
     actual?: T;
   }> = expected.map(entry => {
+    if (seenExpected.has(entry.identity)) {
+      throw new Error(`Duplicate state-diff identity: ${entry.identity}`);
+    }
+    seenExpected.add(entry.identity);
     const match = remaining.get(entry.identity);
     remaining.delete(entry.identity);
     return {
@@ -385,11 +395,13 @@ export const getStepCounts = (items: ValidationItemsByStep): StepCounts =>
     { taskOrigin: 0, signing: 0, overrides: 0, changes: 0, balance: 0 } satisfies StepCounts
   );
 
+const sameHex = (left: string, right: string) => left.toLowerCase() === right.toLowerCase();
+
 const matchesOverride = (comparison: OverrideComparison) =>
   Boolean(
     comparison.expected &&
     comparison.actual &&
-    comparison.expected.key === comparison.actual.key &&
+    sameHex(comparison.expected.key, comparison.actual.key) &&
     comparison.expected.value === comparison.actual.value
   );
 
@@ -397,7 +409,7 @@ const matchesChange = (comparison: StateChangeComparison) =>
   Boolean(
     comparison.expected &&
     comparison.actual &&
-    comparison.expected.key === comparison.actual.key &&
+    sameHex(comparison.expected.key, comparison.actual.key) &&
     comparison.expected.before === comparison.actual.before &&
     comparison.expected.after === comparison.actual.after
   );

--- a/src/lib/validation-results-utils.ts
+++ b/src/lib/validation-results-utils.ts
@@ -265,50 +265,31 @@ type Pairable<T> = {
   item: T;
 };
 
-const pairByIdentity = <E, A>(
-  expected: Pairable<E>[],
-  actual: Pairable<A>[]
-): Array<{
-  contractName: string;
-  contractAddress: string;
-  expected?: E;
-  actual?: A;
-}> => {
-  const remaining = new Map<string, Pairable<A>[]>();
-  for (const entry of actual) {
-    const bucket = remaining.get(entry.identity);
-    if (bucket) bucket.push(entry);
-    else remaining.set(entry.identity, [entry]);
-  }
-
+const pairByIdentity = <T>(expected: Pairable<T>[], actual: Pairable<T>[]) => {
+  // ponytail: last-write wins on duplicate address:slot; use buckets if a task emits dupes
+  const remaining = new Map(actual.map(entry => [entry.identity, entry]));
   const rows: Array<{
     contractName: string;
     contractAddress: string;
-    expected?: E;
-    actual?: A;
-  }> = [];
-
-  for (const entry of expected) {
-    const match = remaining.get(entry.identity)?.shift();
-    rows.push({
+    expected?: T;
+    actual?: T;
+  }> = expected.map(entry => {
+    const match = remaining.get(entry.identity);
+    remaining.delete(entry.identity);
+    return {
       contractName: entry.contractName,
       contractAddress: entry.contractAddress,
       expected: entry.item,
       actual: match?.item,
+    };
+  });
+  for (const entry of remaining.values()) {
+    rows.push({
+      contractName: entry.contractName,
+      contractAddress: entry.contractAddress,
+      actual: entry.item,
     });
   }
-
-  for (const bucket of remaining.values()) {
-    for (const entry of bucket) {
-      rows.push({
-        contractName: entry.contractName,
-        contractAddress: entry.contractAddress,
-        expected: undefined,
-        actual: entry.item,
-      });
-    }
-  }
-
   return rows;
 };
 
@@ -457,18 +438,6 @@ export const hasBlockingErrors = (items: ValidationItemsByStep): boolean => {
 
   return items.balance.some(balance => isUndeclaredOrMismatch(balance, matchesBalance));
 };
-
-export const listUndeclaredResults = (items: ValidationItemsByStep): string[] => [
-  ...items.overrides
-    .filter(item => !item.expected && item.actual)
-    .map(item => `override ${item.contractAddress}:${item.actual?.key}`),
-  ...items.changes
-    .filter(item => !item.expected && item.actual)
-    .map(item => `change ${item.contractAddress}:${item.actual?.key}`),
-  ...items.balance
-    .filter(item => !item.expected && item.actual)
-    .map(item => `balance ${item.contractAddress}:${item.actual?.field}`),
-];
 
 const defaultContractAddress = (address?: string) =>
   address && address.trim().length > 0 ? address : 'Unknown Address';

--- a/src/lib/validation-results-utils.ts
+++ b/src/lib/validation-results-utils.ts
@@ -255,21 +255,91 @@ const buildSigningComparisons = (
   ];
 };
 
+const identityKey = (address: string, slot: string): string =>
+  `${address.toLowerCase()}:${slot.toLowerCase()}`;
+
+type Pairable<T> = {
+  contractName: string;
+  contractAddress: string;
+  identity: string;
+  item: T;
+};
+
+const pairByIdentity = <E, A>(
+  expected: Pairable<E>[],
+  actual: Pairable<A>[]
+): Array<{
+  contractName: string;
+  contractAddress: string;
+  expected?: E;
+  actual?: A;
+}> => {
+  const remaining = new Map<string, Pairable<A>[]>();
+  for (const entry of actual) {
+    const bucket = remaining.get(entry.identity);
+    if (bucket) bucket.push(entry);
+    else remaining.set(entry.identity, [entry]);
+  }
+
+  const rows: Array<{
+    contractName: string;
+    contractAddress: string;
+    expected?: E;
+    actual?: A;
+  }> = [];
+
+  for (const entry of expected) {
+    const match = remaining.get(entry.identity)?.shift();
+    rows.push({
+      contractName: entry.contractName,
+      contractAddress: entry.contractAddress,
+      expected: entry.item,
+      actual: match?.item,
+    });
+  }
+
+  for (const bucket of remaining.values()) {
+    for (const entry of bucket) {
+      rows.push({
+        contractName: entry.contractName,
+        contractAddress: entry.contractAddress,
+        expected: undefined,
+        actual: entry.item,
+      });
+    }
+  }
+
+  return rows;
+};
+
+const flattenOverrides = (groups: NonNullable<ValidationData['expected']['stateOverrides']>) =>
+  groups.flatMap(group =>
+    group.overrides.map(item => ({
+      contractName: group.name,
+      contractAddress: group.address,
+      identity: identityKey(group.address, item.key),
+      item,
+    }))
+  );
+
+const flattenChanges = (groups: NonNullable<ValidationData['expected']['stateChanges']>) =>
+  groups.flatMap(group =>
+    group.changes.map(item => ({
+      contractName: group.name,
+      contractAddress: group.address,
+      identity: identityKey(group.address, item.key),
+      item,
+    }))
+  );
+
 const buildOverrideComparisons = (
   validationResult: ValidationData | null
 ): OverrideComparison[] => {
   if (!validationResult) return [];
 
-  const expectedOverrides = validationResult.expected.stateOverrides ?? [];
-  const actualOverrides = validationResult.actual.stateOverrides ?? [];
-
-  return expectedOverrides.flatMap((stateOverride, soIndex) =>
-    stateOverride.overrides.map((override, oIndex) => ({
-      contractName: stateOverride.name,
-      contractAddress: stateOverride.address,
-      expected: override,
-      actual: actualOverrides[soIndex]?.overrides?.[oIndex],
-    }))
+  return pairByIdentity(
+    flattenOverrides(validationResult.expected.stateOverrides ?? []),
+    flattenOverrides(validationResult.actual.stateOverrides ?? [])
   );
 };
 
@@ -278,16 +348,9 @@ const buildChangeComparisons = (
 ): StateChangeComparison[] => {
   if (!validationResult) return [];
 
-  const expectedChanges = validationResult.expected.stateChanges ?? [];
-  const actualChanges = validationResult.actual.stateChanges ?? [];
-
-  return expectedChanges.flatMap((stateChange, scIndex) =>
-    stateChange.changes.map((change, cIndex) => ({
-      contractName: stateChange.name,
-      contractAddress: stateChange.address,
-      expected: change,
-      actual: actualChanges[scIndex]?.changes?.[cIndex],
-    }))
+  return pairByIdentity(
+    flattenChanges(validationResult.expected.stateChanges ?? []),
+    flattenChanges(validationResult.actual.stateChanges ?? [])
   );
 };
 
@@ -299,12 +362,20 @@ const buildBalanceComparisons = (
   const expectedBalances = validationResult.expected.balanceChanges ?? [];
   const actualBalances = validationResult.actual.balanceChanges ?? [];
 
-  return expectedBalances.map((balanceChange, bcIndex) => ({
-    contractName: balanceChange.name,
-    contractAddress: balanceChange.address,
-    expected: balanceChange,
-    actual: actualBalances[bcIndex],
-  }));
+  return pairByIdentity(
+    expectedBalances.map(balance => ({
+      contractName: balance.name,
+      contractAddress: balance.address,
+      identity: identityKey(balance.address, balance.field),
+      item: balance,
+    })),
+    actualBalances.map(balance => ({
+      contractName: balance.name,
+      contractAddress: balance.address,
+      identity: identityKey(balance.address, balance.field),
+      item: balance,
+    }))
+  );
 };
 
 export const buildValidationItems = (
@@ -334,21 +405,37 @@ export const getStepCounts = (items: ValidationItemsByStep): StepCounts =>
   );
 
 const matchesOverride = (comparison: OverrideComparison) =>
-  comparison.actual &&
-  comparison.expected.key === comparison.actual.key &&
-  comparison.expected.value === comparison.actual.value;
+  Boolean(
+    comparison.expected &&
+    comparison.actual &&
+    comparison.expected.key === comparison.actual.key &&
+    comparison.expected.value === comparison.actual.value
+  );
 
 const matchesChange = (comparison: StateChangeComparison) =>
-  comparison.actual &&
-  comparison.expected.key === comparison.actual.key &&
-  comparison.expected.before === comparison.actual.before &&
-  comparison.expected.after === comparison.actual.after;
+  Boolean(
+    comparison.expected &&
+    comparison.actual &&
+    comparison.expected.key === comparison.actual.key &&
+    comparison.expected.before === comparison.actual.before &&
+    comparison.expected.after === comparison.actual.after
+  );
 
 const matchesBalance = (comparison: BalanceChangeComparison) =>
-  comparison.actual &&
-  comparison.expected.field === comparison.actual.field &&
-  comparison.expected.before === comparison.actual.before &&
-  comparison.expected.after === comparison.actual.after;
+  Boolean(
+    comparison.expected &&
+    comparison.actual &&
+    comparison.expected.field === comparison.actual.field &&
+    comparison.expected.before === comparison.actual.before &&
+    comparison.expected.after === comparison.actual.after
+  );
+
+const isUndeclaredOrMismatch = <
+  T extends { expected?: { allowDifference?: boolean }; actual?: unknown },
+>(
+  item: T,
+  matches: (item: T) => boolean
+): boolean => !item.expected || !item.actual || (!matches(item) && !item.expected.allowDifference);
 
 export const hasBlockingErrors = (items: ValidationItemsByStep): boolean => {
   // Task origin validation failures are blocking (but disabled validation is not a blocking error)
@@ -360,22 +447,28 @@ export const hasBlockingErrors = (items: ValidationItemsByStep): boolean => {
   );
   if (signingMismatch) return true;
 
-  const overrideMismatch = items.overrides.some(
-    override =>
-      !override.actual || (!matchesOverride(override) && !override.expected.allowDifference)
-  );
-  if (overrideMismatch) return true;
+  if (items.overrides.some(override => isUndeclaredOrMismatch(override, matchesOverride))) {
+    return true;
+  }
 
-  const changeMismatch = items.changes.some(
-    change => !change.actual || (!matchesChange(change) && !change.expected.allowDifference)
-  );
-  if (changeMismatch) return true;
+  if (items.changes.some(change => isUndeclaredOrMismatch(change, matchesChange))) {
+    return true;
+  }
 
-  const balanceMismatch = items.balance.some(
-    balance => !balance.actual || (!matchesBalance(balance) && !balance.expected.allowDifference)
-  );
-  return balanceMismatch;
+  return items.balance.some(balance => isUndeclaredOrMismatch(balance, matchesBalance));
 };
+
+export const listUndeclaredResults = (items: ValidationItemsByStep): string[] => [
+  ...items.overrides
+    .filter(item => !item.expected && item.actual)
+    .map(item => `override ${item.contractAddress}:${item.actual?.key}`),
+  ...items.changes
+    .filter(item => !item.expected && item.actual)
+    .map(item => `change ${item.contractAddress}:${item.actual?.key}`),
+  ...items.balance
+    .filter(item => !item.expected && item.actual)
+    .map(item => `balance ${item.contractAddress}:${item.actual?.field}`),
+];
 
 const defaultContractAddress = (address?: string) =>
   address && address.trim().length > 0 ? address : 'Unknown Address';
@@ -399,6 +492,51 @@ const createMatchStatus = (
 const assertNever = (value: never): never => {
   throw new Error(`Unhandled entry kind: ${(value as ValidationNavEntry).kind}`);
 };
+
+const UNDECLARED_DESCRIPTION: ValidationDescription = {
+  variant: 'error',
+  icon: 'x',
+  title: 'Undeclared Change',
+  text: 'The simulation produced this result, but it was not listed in the task config. Signing is blocked until it is declared or removed.',
+};
+
+const evaluateUndeclaredEntry = (
+  stepLabel: string,
+  contractName: string,
+  contractAddress: string,
+  storageKey: string,
+  afterValue: string,
+  beforeValue?: string
+): ValidationEntryEvaluation => ({
+  matchStatus: createMatchStatus(
+    'mismatch',
+    'Unexpected - This result was not declared in the expected config'
+  ),
+  description: UNDECLARED_DESCRIPTION,
+  stepLabel,
+  contractName,
+  cards: {
+    expected: {
+      contractName,
+      contractAddress,
+      storageKey: NOT_FOUND_TEXT,
+      beforeValue: beforeValue === undefined ? undefined : NOT_FOUND_TEXT,
+      afterValue: NOT_FOUND_TEXT,
+    },
+    actual: {
+      contractName,
+      contractAddress,
+      storageKey,
+      storageKeyDiffs: getFieldDiffs(NOT_FOUND_TEXT, storageKey),
+      beforeValue,
+      beforeValueDiffs:
+        beforeValue === undefined ? undefined : getFieldDiffs(NOT_FOUND_TEXT, beforeValue),
+      afterValue,
+      afterValueDiffs: getFieldDiffs(NOT_FOUND_TEXT, afterValue),
+      shouldWrap: true,
+    },
+  },
+});
 
 export const evaluateValidationEntry = (
   entry: ValidationNavEntry,
@@ -526,6 +664,15 @@ export const evaluateValidationEntry = (
     }
     case 'override': {
       const item = items.overrides[entry.index]!;
+      if (!item.expected) {
+        return evaluateUndeclaredEntry(
+          STEP_DEFINITION_MAP.override.label,
+          item.contractName,
+          defaultContractAddress(item.contractAddress),
+          item.actual?.key ?? NOT_FOUND_TEXT,
+          item.actual?.value ?? NOT_FOUND_TEXT
+        );
+      }
       const actualKey = item.actual?.key ?? NOT_FOUND_TEXT;
       const actualValue = item.actual?.value ?? NOT_FOUND_TEXT;
       const match = matchesOverride(item);
@@ -584,6 +731,16 @@ export const evaluateValidationEntry = (
     }
     case 'change': {
       const item = items.changes[entry.index]!;
+      if (!item.expected) {
+        return evaluateUndeclaredEntry(
+          STEP_DEFINITION_MAP.change.label,
+          item.contractName,
+          defaultContractAddress(item.contractAddress),
+          item.actual?.key ?? NOT_FOUND_TEXT,
+          item.actual?.after ?? NOT_FOUND_TEXT,
+          item.actual?.before ?? NOT_FOUND_TEXT
+        );
+      }
       const actualKey = item.actual?.key ?? NOT_FOUND_TEXT;
       const actualBefore = item.actual?.before ?? NOT_FOUND_TEXT;
       const actualAfter = item.actual?.after ?? NOT_FOUND_TEXT;
@@ -646,6 +803,18 @@ export const evaluateValidationEntry = (
     }
     case 'balance': {
       const item = items.balance[entry.index]!;
+      if (!item.expected) {
+        const actualBefore = item.actual ? formatBalanceValue(item.actual.before) : NOT_FOUND_TEXT;
+        const actualAfter = item.actual ? formatBalanceValue(item.actual.after) : NOT_FOUND_TEXT;
+        return evaluateUndeclaredEntry(
+          STEP_DEFINITION_MAP.balance.label,
+          item.contractName,
+          defaultContractAddress(item.contractAddress),
+          item.actual?.field ?? NOT_FOUND_TEXT,
+          actualAfter,
+          actualBefore
+        );
+      }
       const actualField = item.actual?.field ?? NOT_FOUND_TEXT;
       const match = matchesBalance(item);
       const expectedDifference = item.expected.allowDifference;

--- a/src/lib/validation-results-utils.ts
+++ b/src/lib/validation-results-utils.ts
@@ -266,26 +266,20 @@ type Pairable<T> = {
 };
 
 const pairByIdentity = <T>(expected: Pairable<T>[], actual: Pairable<T>[]) => {
-  const remaining = new Map<string, Pairable<T>>();
+  const remaining = new Map<string, Pairable<T>[]>();
   for (const entry of actual) {
-    if (remaining.has(entry.identity)) {
-      throw new Error(`Duplicate state-diff identity: ${entry.identity}`);
-    }
-    remaining.set(entry.identity, entry);
+    const bucket = remaining.get(entry.identity);
+    if (bucket) bucket.push(entry);
+    else remaining.set(entry.identity, [entry]);
   }
-  const seenExpected = new Set<string>();
+
   const rows: Array<{
     contractName: string;
     contractAddress: string;
     expected?: T;
     actual?: T;
   }> = expected.map(entry => {
-    if (seenExpected.has(entry.identity)) {
-      throw new Error(`Duplicate state-diff identity: ${entry.identity}`);
-    }
-    seenExpected.add(entry.identity);
-    const match = remaining.get(entry.identity);
-    remaining.delete(entry.identity);
+    const match = remaining.get(entry.identity)?.shift();
     return {
       contractName: entry.contractName,
       contractAddress: entry.contractAddress,
@@ -293,12 +287,14 @@ const pairByIdentity = <T>(expected: Pairable<T>[], actual: Pairable<T>[]) => {
       actual: match?.item,
     };
   });
-  for (const entry of remaining.values()) {
-    rows.push({
-      contractName: entry.contractName,
-      contractAddress: entry.contractAddress,
-      actual: entry.item,
-    });
+  for (const bucket of remaining.values()) {
+    for (const entry of bucket) {
+      rows.push({
+        contractName: entry.contractName,
+        contractAddress: entry.contractAddress,
+        actual: entry.item,
+      });
+    }
   }
   return rows;
 };
@@ -402,7 +398,7 @@ const matchesOverride = (comparison: OverrideComparison) =>
     comparison.expected &&
     comparison.actual &&
     sameHex(comparison.expected.key, comparison.actual.key) &&
-    comparison.expected.value === comparison.actual.value
+    sameHex(comparison.expected.value, comparison.actual.value)
   );
 
 const matchesChange = (comparison: StateChangeComparison) =>
@@ -410,17 +406,17 @@ const matchesChange = (comparison: StateChangeComparison) =>
     comparison.expected &&
     comparison.actual &&
     sameHex(comparison.expected.key, comparison.actual.key) &&
-    comparison.expected.before === comparison.actual.before &&
-    comparison.expected.after === comparison.actual.after
+    sameHex(comparison.expected.before, comparison.actual.before) &&
+    sameHex(comparison.expected.after, comparison.actual.after)
   );
 
 const matchesBalance = (comparison: BalanceChangeComparison) =>
   Boolean(
     comparison.expected &&
     comparison.actual &&
-    comparison.expected.field === comparison.actual.field &&
-    comparison.expected.before === comparison.actual.before &&
-    comparison.expected.after === comparison.actual.after
+    comparison.expected.field.toLowerCase() === comparison.actual.field.toLowerCase() &&
+    sameHex(comparison.expected.before, comparison.actual.before) &&
+    sameHex(comparison.expected.after, comparison.actual.after)
   );
 
 const isUndeclaredOrMismatch = <

--- a/src/lib/validation-service.ts
+++ b/src/lib/validation-service.ts
@@ -19,11 +19,7 @@ import {
   TaskOriginSignerResult,
   TaskOriginValidation,
 } from './types/index';
-import {
-  buildValidationItems,
-  listUndeclaredResults,
-  TASK_ORIGIN_ROLE_LABELS,
-} from './validation-results-utils';
+import { TASK_ORIGIN_ROLE_LABELS } from './validation-results-utils';
 
 export type ValidationServiceOpts = {
   upgradeId: string;
@@ -139,6 +135,38 @@ async function runStateDiffSimulation(
   } catch (error) {
     console.error('❌ State-diff simulation failed:', error);
     throw error;
+  }
+}
+
+const slotId = (address: string, slot: string) => `${address.toLowerCase()}:${slot.toLowerCase()}`;
+
+function undeclaredIds(declared: string[], actual: string[]): string[] {
+  const expected = new Set(declared);
+  return actual.filter(id => !expected.has(id));
+}
+
+function assertNoUndeclaredResults(
+  expected: ValidationData['expected'],
+  actual: ValidationData['actual']
+): void {
+  const undeclared = [
+    ...undeclaredIds(
+      expected.stateOverrides.flatMap(g => g.overrides.map(o => slotId(g.address, o.key))),
+      actual.stateOverrides.flatMap(g => g.overrides.map(o => slotId(g.address, o.key)))
+    ),
+    ...undeclaredIds(
+      expected.stateChanges.flatMap(g => g.changes.map(c => slotId(g.address, c.key))),
+      actual.stateChanges.flatMap(g => g.changes.map(c => slotId(g.address, c.key)))
+    ),
+    ...undeclaredIds(
+      (expected.balanceChanges ?? []).map(b => slotId(b.address, b.field)),
+      (actual.balanceChanges ?? []).map(b => slotId(b.address, b.field))
+    ),
+  ];
+  if (undeclared.length > 0) {
+    throw new Error(
+      `ValidationService::validateUpgrade: simulation produced undeclared results: ${undeclared.join('; ')}`
+    );
   }
 }
 
@@ -307,14 +335,7 @@ export async function validateUpgrade(opts: ValidationServiceOpts): Promise<Vali
   // Run the task simulation
   const expected = getExpectedData(cfg);
   const actual = await runStateDiffSimulation(scriptPath, cfg);
-  const undeclared = listUndeclaredResults(
-    buildValidationItems({ expected, actual, taskOriginValidation })
-  );
-  if (undeclared.length > 0) {
-    throw new Error(
-      `ValidationService::validateUpgrade: simulation produced undeclared results: ${undeclared.join('; ')}`
-    );
-  }
+  assertNoUndeclaredResults(expected, actual);
 
   return {
     expected,

--- a/src/lib/validation-service.ts
+++ b/src/lib/validation-service.ts
@@ -138,38 +138,6 @@ async function runStateDiffSimulation(
   }
 }
 
-const slotId = (address: string, slot: string) => `${address.toLowerCase()}:${slot.toLowerCase()}`;
-
-function undeclaredIds(declared: string[], actual: string[]): string[] {
-  const expected = new Set(declared);
-  return actual.filter(id => !expected.has(id));
-}
-
-function assertNoUndeclaredResults(
-  expected: ValidationData['expected'],
-  actual: ValidationData['actual']
-): void {
-  const undeclared = [
-    ...undeclaredIds(
-      expected.stateOverrides.flatMap(g => g.overrides.map(o => slotId(g.address, o.key))),
-      actual.stateOverrides.flatMap(g => g.overrides.map(o => slotId(g.address, o.key)))
-    ),
-    ...undeclaredIds(
-      expected.stateChanges.flatMap(g => g.changes.map(c => slotId(g.address, c.key))),
-      actual.stateChanges.flatMap(g => g.changes.map(c => slotId(g.address, c.key)))
-    ),
-    ...undeclaredIds(
-      (expected.balanceChanges ?? []).map(b => slotId(b.address, b.field)),
-      (actual.balanceChanges ?? []).map(b => slotId(b.address, b.field))
-    ),
-  ];
-  if (undeclared.length > 0) {
-    throw new Error(
-      `ValidationService::validateUpgrade: simulation produced undeclared results: ${undeclared.join('; ')}`
-    );
-  }
-}
-
 async function validateSigner(
   taskOriginDir: string,
   signatureDir: string,
@@ -335,7 +303,6 @@ export async function validateUpgrade(opts: ValidationServiceOpts): Promise<Vali
   // Run the task simulation
   const expected = getExpectedData(cfg);
   const actual = await runStateDiffSimulation(scriptPath, cfg);
-  assertNoUndeclaredResults(expected, actual);
 
   return {
     expected,

--- a/src/lib/validation-service.ts
+++ b/src/lib/validation-service.ts
@@ -19,7 +19,11 @@ import {
   TaskOriginSignerResult,
   TaskOriginValidation,
 } from './types/index';
-import { TASK_ORIGIN_ROLE_LABELS } from './validation-results-utils';
+import {
+  buildValidationItems,
+  listUndeclaredResults,
+  TASK_ORIGIN_ROLE_LABELS,
+} from './validation-results-utils';
 
 export type ValidationServiceOpts = {
   upgradeId: string;
@@ -303,6 +307,14 @@ export async function validateUpgrade(opts: ValidationServiceOpts): Promise<Vali
   // Run the task simulation
   const expected = getExpectedData(cfg);
   const actual = await runStateDiffSimulation(scriptPath, cfg);
+  const undeclared = listUndeclaredResults(
+    buildValidationItems({ expected, actual, taskOriginValidation })
+  );
+  if (undeclared.length > 0) {
+    throw new Error(
+      `ValidationService::validateUpgrade: simulation produced undeclared results: ${undeclared.join('; ')}`
+    );
+  }
 
   return {
     expected,


### PR DESCRIPTION
## Summary
- Pair expected vs actual state overrides, changes, and balances by `(address, slot/field)` instead of array index, so extra simulation results cannot be dropped.
- Surface undeclared actual entries as blocking unexpected rows (`hasBlockingErrors()` returns true). Duplicate identities stay on the review screen as blocking unexpected/missing rows.
- Hex keys and values compare case-insensitively, and case-only differences are not highlighted on a match.

Fixes [SECBUGS-24878](https://coinbase.atlassian.net/browse/SECBUGS-24878). Fixes H1#3945949.

## Test plan
- [x] `npm test -- src/lib/__tests__/validation-results-utils.test.ts` (match, declared mismatch, undeclared extras, reorder, duplicates, case-insensitive hex)
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build`